### PR TITLE
Enroll cuVS artifacts in the release catalog

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -43,7 +43,7 @@ jobs:
       packages: read
       pull-requests: read
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-build.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-build.yaml@codex/release-build-output-manifests
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
       branch: ${{ inputs.branch }}
@@ -51,6 +51,8 @@ jobs:
       node_type: cpu16
       script: ci/build_cpp.sh
       sha: ${{ inputs.sha }}
+      release-build-output: true
+      release-unit: conda:cuvs-cpp
 
   rocky8-clib-standalone-build-matrix:
     permissions:
@@ -82,8 +84,25 @@ jobs:
       requires_license_builder: true
       script: "ci/build_standalone_c.sh"
       artifact-name: "libcuvs_c_${{ matrix.CUDA_VER }}_${{ matrix.ARCH }}.tar.gz"
-      file_to_upload: "libcuvs_c.tar.gz"
+      file_to_upload: |
+        libcuvs_c.tar.gz
+        libcuvs_c.release-package.json
       sha: ${{ inputs.sha }}
+  rocky8-clib-standalone-release-output:
+    needs: [rocky8-clib-standalone-build-matrix, rocky8-clib-standalone-build]
+    permissions:
+      actions: read
+      contents: read
+    uses: rapidsai/shared-workflows/.github/workflows/release-build-output.yaml@codex/release-build-output-manifests
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.rocky8-clib-standalone-build-matrix.outputs.matrix) }}
+    with:
+      artifact-name: "libcuvs_c_${{ matrix.CUDA_VER }}_${{ matrix.ARCH }}.tar.gz"
+      release-unit: archive:libcuvs-c
+      release-package-file: libcuvs_c.release-package.json
+      release-artifacts: '[{"path":"libcuvs_c.tar.gz"}]'
+      source-sha: ${{ inputs.sha || github.sha }}
   rust-build-matrix:
     needs: cpp-build
     permissions:
@@ -184,6 +203,21 @@ jobs:
       artifact-name: "cuvs-java-cuda${{ matrix.CUDA_VER }}"
       file_to_upload: "java/cuvs-java/target/"
       sha: ${{ inputs.sha }}
+  java-release-output:
+    needs: [java-build-matrix, java-build]
+    permissions:
+      actions: read
+      contents: read
+    uses: rapidsai/shared-workflows/.github/workflows/release-build-output.yaml@codex/release-build-output-manifests
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.java-build-matrix.outputs.matrix) }}
+    with:
+      artifact-name: "cuvs-java-cuda${{ matrix.CUDA_VER }}"
+      release-unit: maven:cuvs-java
+      release-package-file: cuvs-java.release-package.json
+      release-artifacts: '[{"path":"cuvs-java-*-x86_64-cuda*.jar"}]'
+      source-sha: ${{ inputs.sha || github.sha }}
   python-build:
     needs: [cpp-build]
     permissions:
@@ -193,13 +227,15 @@ jobs:
       packages: read
       pull-requests: read
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@codex/release-build-output-manifests
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
       branch: ${{ inputs.branch }}
       date: ${{ inputs.date }}
       script: ci/build_python.sh
       sha: ${{ inputs.sha }}
+      release-build-output: true
+      release-unit: conda:cuvs-python
       # Build a conda package for each CUDA x ARCH x minimum supported Python version
       matrix_filter: group_by({CUDA_VER, ARCH}) | map(min_by(.PY_VER | split(".") | map(tonumber)))
   upload-conda:
@@ -254,7 +290,7 @@ jobs:
       packages: read
       pull-requests: read
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@codex/release-build-output-manifests
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
       branch: ${{ inputs.branch }}
@@ -266,6 +302,8 @@ jobs:
       matrix_filter: group_by([.ARCH, (.CUDA_VER|split(".")|map(tonumber)|.[0])]) | map(max_by(.PY_VER|split(".")|map(tonumber)))
       package-name: libcuvs
       package-type: cpp
+      release-build-output: true
+      release-unit: wheel:libcuvs
   wheel-publish-libcuvs:
     needs: wheel-build-libcuvs
     permissions:
@@ -295,7 +333,7 @@ jobs:
       packages: read
       pull-requests: read
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@codex/release-build-output-manifests
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
       branch: ${{ inputs.branch }}
@@ -305,6 +343,8 @@ jobs:
       script: ci/build_wheel_cuvs.sh
       package-name: cuvs
       package-type: python
+      release-build-output: true
+      release-unit: wheel:cuvs
       # Build a wheel for each CUDA x ARCH x minimum supported Python version
       matrix_filter: group_by({CUDA_VER, ARCH}) | map(min_by(.PY_VER | split(".") | map(tonumber)))
   wheel-publish-cuvs:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -92,10 +92,11 @@ jobs:
         libcuvs_c.release-package-identity.json
       release-catalog-config: >-
         {
+          "artifact_type": "custom",
           "release_catalog_key": "archive:libcuvs-c",
+          "package_identity_file": "libcuvs_c.release-package-identity.json",
           "artifacts": [{
-            "path": "libcuvs_c.tar.gz",
-            "package_identity_file": "libcuvs_c.release-package-identity.json"
+            "path": "libcuvs_c.tar.gz"
           }]
         }
       sha: ${{ inputs.sha }}
@@ -200,11 +201,12 @@ jobs:
       file_to_upload: "java/cuvs-java/target/"
       release-catalog-config: >-
         {
+          "artifact_type": "custom",
           "release_catalog_key": "maven:cuvs-java",
-          "artifact_directory": "java/cuvs-java/target",
+          "output_directory": "java/cuvs-java/target",
+          "package_identity_file": "cuvs-java.release-package-identity.json",
           "artifacts": [{
-            "path": "cuvs-java-*-x86_64-cuda*.jar",
-            "package_identity_file": "cuvs-java.release-package-identity.json"
+            "path": "cuvs-java-*-x86_64-cuda*.jar"
           }]
         }
       sha: ${{ inputs.sha }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -92,10 +92,11 @@ jobs:
         libcuvs_c.release-package-identity.json
       release-catalog-config: >-
         {
-          "artifact_type": "custom",
           "release_catalog_key": "archive:libcuvs-c",
-          "package_identity_file": "libcuvs_c.release-package-identity.json",
-          "artifacts": [{"path": "libcuvs_c.tar.gz"}]
+          "artifacts": [{
+            "path": "libcuvs_c.tar.gz",
+            "package_identity_file": "libcuvs_c.release-package-identity.json"
+          }]
         }
       sha: ${{ inputs.sha }}
   rust-build-matrix:
@@ -199,11 +200,12 @@ jobs:
       file_to_upload: "java/cuvs-java/target/"
       release-catalog-config: >-
         {
-          "artifact_type": "custom",
           "release_catalog_key": "maven:cuvs-java",
           "output_directory": "java/cuvs-java/target",
-          "package_identity_file": "cuvs-java.release-package-identity.json",
-          "artifacts": [{"path": "cuvs-java-*-x86_64-cuda*.jar"}]
+          "artifacts": [{
+            "path": "cuvs-java-*-x86_64-cuda*.jar",
+            "package_identity_file": "cuvs-java.release-package-identity.json"
+          }]
         }
       sha: ${{ inputs.sha }}
   python-build:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -90,10 +90,10 @@ jobs:
       file_to_upload: |
         libcuvs_c.tar.gz
         libcuvs_c.release-package.json
-      release-build-output: >-
+      release-catalog-config: >-
         {
           "artifact_type": "custom",
-          "component_id": "archive:libcuvs-c",
+          "release_catalog_key": "archive:libcuvs-c",
           "package_file": "libcuvs_c.release-package.json",
           "artifacts": [{"path": "libcuvs_c.tar.gz"}]
         }
@@ -197,10 +197,10 @@ jobs:
       script: "ci/build_java.sh"
       artifact-name: "cuvs-java-cuda${{ matrix.CUDA_VER }}"
       file_to_upload: "java/cuvs-java/target/"
-      release-build-output: >-
+      release-catalog-config: >-
         {
           "artifact_type": "custom",
-          "component_id": "maven:cuvs-java",
+          "release_catalog_key": "maven:cuvs-java",
           "output_directory": "java/cuvs-java/target",
           "package_file": "cuvs-java.release-package.json",
           "artifacts": [{"path": "cuvs-java-*-x86_64-cuda*.jar"}]

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,9 +24,13 @@ on:
         required: true
         type: string
       build_type:
-        description: "build_type: one of [branch, nightly, pull-request]"
+        description: "build_type: one of [branch, nightly, pull-request, release-candidate]"
         type: string
         default: nightly
+      candidate_train_sha256:
+        description: "Canonical SHA-256 of the release train; required for release-candidate builds."
+        type: string
+        default: ""
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
@@ -55,6 +59,7 @@ jobs:
       node_type: cpu16
       script: ci/build_cpp.sh
       sha: ${{ inputs.sha }}
+      candidate-train-sha256: ${{ inputs.candidate_train_sha256 }}
 
   rocky8-clib-standalone-build-matrix:
     permissions:
@@ -99,6 +104,7 @@ jobs:
           }]
         }
       sha: ${{ inputs.sha }}
+      candidate-train-sha256: ${{ inputs.candidate_train_sha256 }}
   rust-build-matrix:
     needs: cpp-build
     permissions:
@@ -208,6 +214,7 @@ jobs:
           }]
         }
       sha: ${{ inputs.sha }}
+      candidate-train-sha256: ${{ inputs.candidate_train_sha256 }}
   python-build:
     needs: [build-details, cpp-build]
     permissions:
@@ -225,6 +232,7 @@ jobs:
       date: ${{ inputs.date }}
       script: ci/build_python.sh
       sha: ${{ inputs.sha }}
+      candidate-train-sha256: ${{ inputs.candidate_train_sha256 }}
       # Build a conda package for each CUDA x ARCH x minimum supported Python version
       matrix_filter: group_by({CUDA_VER, ARCH}) | map(min_by(.PY_VER | split(".") | map(tonumber)))
   upload-conda:
@@ -293,6 +301,7 @@ jobs:
       matrix_filter: group_by([.ARCH, (.CUDA_VER|split(".")|map(tonumber)|.[0])]) | map(max_by(.PY_VER|split(".")|map(tonumber)))
       package-name: libcuvs
       package-type: cpp
+      candidate-train-sha256: ${{ inputs.candidate_train_sha256 }}
   wheel-publish-libcuvs:
     needs: wheel-build-libcuvs
     permissions:
@@ -333,6 +342,7 @@ jobs:
       script: ci/build_wheel_cuvs.sh
       package-name: cuvs
       package-type: python
+      candidate-train-sha256: ${{ inputs.candidate_train_sha256 }}
       # Build a wheel for each CUDA x ARCH x minimum supported Python version
       matrix_filter: group_by({CUDA_VER, ARCH}) | map(min_by(.PY_VER | split(".") | map(tonumber)))
   wheel-publish-cuvs:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -201,7 +201,7 @@ jobs:
       release-catalog-config: >-
         {
           "release_catalog_key": "maven:cuvs-java",
-          "output_directory": "java/cuvs-java/target",
+          "artifact_directory": "java/cuvs-java/target",
           "artifacts": [{
             "path": "cuvs-java-*-x86_64-cuda*.jar",
             "package_identity_file": "cuvs-java.release-package-identity.json"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -46,7 +46,7 @@ jobs:
       packages: read
       pull-requests: read
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-build.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-build.yaml@codex/release-build-output-manifests
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
       build-datetime: ${{ needs.build-details.outputs.build-datetime }}
@@ -217,7 +217,7 @@ jobs:
       packages: read
       pull-requests: read
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@codex/release-build-output-manifests
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
       build-datetime: ${{ needs.build-details.outputs.build-datetime }}
@@ -280,7 +280,7 @@ jobs:
       packages: read
       pull-requests: read
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@codex/release-build-output-manifests
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
       build-datetime: ${{ needs.build-details.outputs.build-datetime }}
@@ -322,7 +322,7 @@ jobs:
       packages: read
       pull-requests: read
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@codex/release-build-output-manifests
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
       build-datetime: ${{ needs.build-details.outputs.build-datetime }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -72,7 +72,7 @@ jobs:
       packages: read
       pull-requests: read
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@codex/release-build-output-manifests
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.rocky8-clib-standalone-build-matrix.outputs.matrix) }}
@@ -87,7 +87,16 @@ jobs:
       requires_license_builder: true
       script: "ci/build_standalone_c.sh"
       artifact-name: "libcuvs_c_${{ matrix.CUDA_VER }}_${{ matrix.ARCH }}.tar.gz"
-      file_to_upload: "libcuvs_c.tar.gz"
+      file_to_upload: |
+        libcuvs_c.tar.gz
+        libcuvs_c.release-package.json
+      release-build-output: >-
+        {
+          "artifact_type": "custom",
+          "component_id": "archive:libcuvs-c",
+          "package_file": "libcuvs_c.release-package.json",
+          "artifacts": [{"path": "libcuvs_c.tar.gz"}]
+        }
       sha: ${{ inputs.sha }}
   rust-build-matrix:
     needs: cpp-build
@@ -173,7 +182,7 @@ jobs:
       packages: read
       pull-requests: read
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@codex/release-build-output-manifests
     # Artifacts are not published from these jobs, so it's safe to run for multiple CUDA versions.
     # If these jobs start producing artifacts, the names will have to differentiate between CUDA versions.
     strategy:
@@ -188,6 +197,14 @@ jobs:
       script: "ci/build_java.sh"
       artifact-name: "cuvs-java-cuda${{ matrix.CUDA_VER }}"
       file_to_upload: "java/cuvs-java/target/"
+      release-build-output: >-
+        {
+          "artifact_type": "custom",
+          "component_id": "maven:cuvs-java",
+          "output_directory": "java/cuvs-java/target",
+          "package_file": "cuvs-java.release-package.json",
+          "artifacts": [{"path": "cuvs-java-*-x86_64-cuda*.jar"}]
+        }
       sha: ${{ inputs.sha }}
   python-build:
     needs: [build-details, cpp-build]

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -70,7 +70,7 @@ jobs:
       packages: read
       pull-requests: read
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@codex/release-build-output-manifests
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.rocky8-clib-standalone-build-matrix.outputs.matrix) }}
@@ -87,22 +87,12 @@ jobs:
       file_to_upload: |
         libcuvs_c.tar.gz
         libcuvs_c.release-package.json
-      sha: ${{ inputs.sha }}
-  rocky8-clib-standalone-release-output:
-    needs: [rocky8-clib-standalone-build-matrix, rocky8-clib-standalone-build]
-    permissions:
-      actions: read
-      contents: read
-    uses: rapidsai/shared-workflows/.github/workflows/release-build-output.yaml@codex/release-build-output-manifests
-    strategy:
-      fail-fast: false
-      matrix: ${{ fromJSON(needs.rocky8-clib-standalone-build-matrix.outputs.matrix) }}
-    with:
-      artifact-name: "libcuvs_c_${{ matrix.CUDA_VER }}_${{ matrix.ARCH }}.tar.gz"
+      release-build-output: true
+      release-output-directory: .
       release-unit: archive:libcuvs-c
       release-package-file: libcuvs_c.release-package.json
       release-artifacts: '[{"path":"libcuvs_c.tar.gz"}]'
-      source-sha: ${{ inputs.sha || github.sha }}
+      sha: ${{ inputs.sha }}
   rust-build-matrix:
     needs: cpp-build
     permissions:
@@ -187,7 +177,7 @@ jobs:
       packages: read
       pull-requests: read
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@codex/release-build-output-manifests
     # Artifacts are not published from these jobs, so it's safe to run for multiple CUDA versions.
     # If these jobs start producing artifacts, the names will have to differentiate between CUDA versions.
     strategy:
@@ -202,22 +192,12 @@ jobs:
       script: "ci/build_java.sh"
       artifact-name: "cuvs-java-cuda${{ matrix.CUDA_VER }}"
       file_to_upload: "java/cuvs-java/target/"
-      sha: ${{ inputs.sha }}
-  java-release-output:
-    needs: [java-build-matrix, java-build]
-    permissions:
-      actions: read
-      contents: read
-    uses: rapidsai/shared-workflows/.github/workflows/release-build-output.yaml@codex/release-build-output-manifests
-    strategy:
-      fail-fast: false
-      matrix: ${{ fromJSON(needs.java-build-matrix.outputs.matrix) }}
-    with:
-      artifact-name: "cuvs-java-cuda${{ matrix.CUDA_VER }}"
+      release-build-output: true
+      release-output-directory: java/cuvs-java/target
       release-unit: maven:cuvs-java
       release-package-file: cuvs-java.release-package.json
       release-artifacts: '[{"path":"cuvs-java-*-x86_64-cuda*.jar"}]'
-      source-sha: ${{ inputs.sha || github.sha }}
+      sha: ${{ inputs.sha }}
   python-build:
     needs: [cpp-build]
     permissions:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -92,11 +92,10 @@ jobs:
         libcuvs_c.release-package-identity.json
       release-catalog-config: >-
         {
-          "artifact_type": "custom",
           "release_catalog_key": "archive:libcuvs-c",
-          "package_identity_file": "libcuvs_c.release-package-identity.json",
           "artifacts": [{
-            "path": "libcuvs_c.tar.gz"
+            "path": "libcuvs_c.tar.gz",
+            "package_identity_file": "libcuvs_c.release-package-identity.json"
           }]
         }
       sha: ${{ inputs.sha }}
@@ -201,12 +200,11 @@ jobs:
       file_to_upload: "java/cuvs-java/target/"
       release-catalog-config: >-
         {
-          "artifact_type": "custom",
           "release_catalog_key": "maven:cuvs-java",
-          "output_directory": "java/cuvs-java/target",
-          "package_identity_file": "cuvs-java.release-package-identity.json",
+          "artifact_directory": "java/cuvs-java/target",
           "artifacts": [{
-            "path": "cuvs-java-*-x86_64-cuda*.jar"
+            "path": "cuvs-java-*-x86_64-cuda*.jar",
+            "package_identity_file": "cuvs-java.release-package-identity.json"
           }]
         }
       sha: ${{ inputs.sha }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -51,8 +51,6 @@ jobs:
       node_type: cpu16
       script: ci/build_cpp.sh
       sha: ${{ inputs.sha }}
-      release-build-output: true
-      release-unit: conda:cuvs-cpp
 
   rocky8-clib-standalone-build-matrix:
     permissions:
@@ -214,8 +212,6 @@ jobs:
       date: ${{ inputs.date }}
       script: ci/build_python.sh
       sha: ${{ inputs.sha }}
-      release-build-output: true
-      release-unit: conda:cuvs-python
       # Build a conda package for each CUDA x ARCH x minimum supported Python version
       matrix_filter: group_by({CUDA_VER, ARCH}) | map(min_by(.PY_VER | split(".") | map(tonumber)))
   upload-conda:
@@ -282,8 +278,6 @@ jobs:
       matrix_filter: group_by([.ARCH, (.CUDA_VER|split(".")|map(tonumber)|.[0])]) | map(max_by(.PY_VER|split(".")|map(tonumber)))
       package-name: libcuvs
       package-type: cpp
-      release-build-output: true
-      release-unit: wheel:libcuvs
   wheel-publish-libcuvs:
     needs: wheel-build-libcuvs
     permissions:
@@ -323,8 +317,6 @@ jobs:
       script: ci/build_wheel_cuvs.sh
       package-name: cuvs
       package-type: python
-      release-build-output: true
-      release-unit: wheel:cuvs
       # Build a wheel for each CUDA x ARCH x minimum supported Python version
       matrix_filter: group_by({CUDA_VER, ARCH}) | map(min_by(.PY_VER | split(".") | map(tonumber)))
   wheel-publish-cuvs:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -89,12 +89,12 @@ jobs:
       artifact-name: "libcuvs_c_${{ matrix.CUDA_VER }}_${{ matrix.ARCH }}.tar.gz"
       file_to_upload: |
         libcuvs_c.tar.gz
-        libcuvs_c.release-package.json
+        libcuvs_c.release-package-identity.json
       release-catalog-config: >-
         {
           "artifact_type": "custom",
           "release_catalog_key": "archive:libcuvs-c",
-          "package_file": "libcuvs_c.release-package.json",
+          "package_identity_file": "libcuvs_c.release-package-identity.json",
           "artifacts": [{"path": "libcuvs_c.tar.gz"}]
         }
       sha: ${{ inputs.sha }}
@@ -202,7 +202,7 @@ jobs:
           "artifact_type": "custom",
           "release_catalog_key": "maven:cuvs-java",
           "output_directory": "java/cuvs-java/target",
-          "package_file": "cuvs-java.release-package.json",
+          "package_identity_file": "cuvs-java.release-package-identity.json",
           "artifacts": [{"path": "cuvs-java-*-x86_64-cuda*.jar"}]
         }
       sha: ${{ inputs.sha }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -31,6 +31,10 @@ on:
         description: "Canonical SHA-256 of the release train; required for release-candidate builds."
         type: string
         default: ""
+      candidate_release_tag:
+        description: "Final source tag created locally for a release-candidate build."
+        type: string
+        default: "v26.10.00"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
@@ -60,6 +64,7 @@ jobs:
       script: ci/build_cpp.sh
       sha: ${{ inputs.sha }}
       candidate-train-sha256: ${{ inputs.candidate_train_sha256 }}
+      release-candidate-tag: ${{ inputs.candidate_release_tag }}
 
   rocky8-clib-standalone-build-matrix:
     permissions:
@@ -105,6 +110,7 @@ jobs:
         }
       sha: ${{ inputs.sha }}
       candidate-train-sha256: ${{ inputs.candidate_train_sha256 }}
+      release-candidate-tag: ${{ inputs.candidate_release_tag }}
   rust-build-matrix:
     needs: cpp-build
     permissions:
@@ -215,6 +221,7 @@ jobs:
         }
       sha: ${{ inputs.sha }}
       candidate-train-sha256: ${{ inputs.candidate_train_sha256 }}
+      release-candidate-tag: ${{ inputs.candidate_release_tag }}
   python-build:
     needs: [build-details, cpp-build]
     permissions:
@@ -233,6 +240,7 @@ jobs:
       script: ci/build_python.sh
       sha: ${{ inputs.sha }}
       candidate-train-sha256: ${{ inputs.candidate_train_sha256 }}
+      release-candidate-tag: ${{ inputs.candidate_release_tag }}
       # Build a conda package for each CUDA x ARCH x minimum supported Python version
       matrix_filter: group_by({CUDA_VER, ARCH}) | map(min_by(.PY_VER | split(".") | map(tonumber)))
   upload-conda:
@@ -302,6 +310,7 @@ jobs:
       package-name: libcuvs
       package-type: cpp
       candidate-train-sha256: ${{ inputs.candidate_train_sha256 }}
+      release-candidate-tag: ${{ inputs.candidate_release_tag }}
   wheel-publish-libcuvs:
     needs: wheel-build-libcuvs
     permissions:
@@ -343,6 +352,7 @@ jobs:
       package-name: cuvs
       package-type: python
       candidate-train-sha256: ${{ inputs.candidate_train_sha256 }}
+      release-candidate-tag: ${{ inputs.candidate_release_tag }}
       # Build a wheel for each CUDA x ARCH x minimum supported Python version
       matrix_filter: group_by({CUDA_VER, ARCH}) | map(min_by(.PY_VER | split(".") | map(tonumber)))
   wheel-publish-cuvs:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -537,10 +537,10 @@ jobs:
       file_to_upload: |
         libcuvs_c.tar.gz
         libcuvs_c.release-package.json
-      release-build-output: >-
+      release-catalog-config: >-
         {
           "artifact_type": "custom",
-          "component_id": "archive:libcuvs-c",
+          "release_catalog_key": "archive:libcuvs-c",
           "package_file": "libcuvs_c.release-package.json",
           "artifacts": [{"path": "libcuvs_c.tar.gz"}]
         }
@@ -608,10 +608,10 @@ jobs:
       script: "ci/test_java.sh"
       artifact-name: "cuvs-java-cuda${{ matrix.CUDA_VER }}"
       file_to_upload: "java/cuvs-java/target/"
-      release-build-output: >-
+      release-catalog-config: >-
         {
           "artifact_type": "custom",
-          "component_id": "maven:cuvs-java",
+          "release_catalog_key": "maven:cuvs-java",
           "output_directory": "java/cuvs-java/target",
           "package_file": "cuvs-java.release-package.json",
           "artifacts": [{"path": "cuvs-java-*-x86_64-cuda*.jar"}]

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -539,10 +539,11 @@ jobs:
         libcuvs_c.release-package-identity.json
       release-catalog-config: >-
         {
+          "artifact_type": "custom",
           "release_catalog_key": "archive:libcuvs-c",
+          "package_identity_file": "libcuvs_c.release-package-identity.json",
           "artifacts": [{
-            "path": "libcuvs_c.tar.gz",
-            "package_identity_file": "libcuvs_c.release-package-identity.json"
+            "path": "libcuvs_c.tar.gz"
           }]
         }
       sha: ${{ inputs.sha }}
@@ -611,11 +612,12 @@ jobs:
       file_to_upload: "java/cuvs-java/target/"
       release-catalog-config: >-
         {
+          "artifact_type": "custom",
           "release_catalog_key": "maven:cuvs-java",
-          "artifact_directory": "java/cuvs-java/target",
+          "output_directory": "java/cuvs-java/target",
+          "package_identity_file": "cuvs-java.release-package-identity.json",
           "artifacts": [{
-            "path": "cuvs-java-*-x86_64-cuda*.jar",
-            "package_identity_file": "cuvs-java.release-package-identity.json"
+            "path": "cuvs-java-*-x86_64-cuda*.jar"
           }]
         }
   rust-build-matrix:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -520,7 +520,7 @@ jobs:
       packages: read
       pull-requests: read
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@codex/release-build-output-manifests
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.rocky8-clib-standalone-build-matrix.outputs.matrix) }}
@@ -534,7 +534,16 @@ jobs:
       requires_license_builder: true
       script: "ci/build_standalone_c.sh --build-tests"
       artifact-name: "libcuvs_c_${{ matrix.CUDA_VER }}_${{ matrix.ARCH }}.tar.gz"
-      file_to_upload: "libcuvs_c.tar.gz"
+      file_to_upload: |
+        libcuvs_c.tar.gz
+        libcuvs_c.release-package.json
+      release-build-output: >-
+        {
+          "artifact_type": "custom",
+          "component_id": "archive:libcuvs-c",
+          "package_file": "libcuvs_c.release-package.json",
+          "artifacts": [{"path": "libcuvs_c.tar.gz"}]
+        }
       sha: ${{ inputs.sha }}
   rocky8-clib-tests-matrix:
     needs: [rocky8-clib-standalone-build, changed-files]
@@ -585,7 +594,7 @@ jobs:
       packages: read
       pull-requests: read
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@codex/release-build-output-manifests
     # Artifacts are not published from these jobs, so it's safe to run for multiple CUDA versions.
     # If these jobs start producing artifacts, the names will have to differentiate between CUDA versions.
     strategy:
@@ -599,6 +608,14 @@ jobs:
       script: "ci/test_java.sh"
       artifact-name: "cuvs-java-cuda${{ matrix.CUDA_VER }}"
       file_to_upload: "java/cuvs-java/target/"
+      release-build-output: >-
+        {
+          "artifact_type": "custom",
+          "component_id": "maven:cuvs-java",
+          "output_directory": "java/cuvs-java/target",
+          "package_file": "cuvs-java.release-package.json",
+          "artifacts": [{"path": "cuvs-java-*-x86_64-cuda*.jar"}]
+        }
   rust-build-matrix:
     needs: [conda-cpp-build, changed-files]
     permissions:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -612,7 +612,7 @@ jobs:
       release-catalog-config: >-
         {
           "release_catalog_key": "maven:cuvs-java",
-          "output_directory": "java/cuvs-java/target",
+          "artifact_directory": "java/cuvs-java/target",
           "artifacts": [{
             "path": "cuvs-java-*-x86_64-cuda*.jar",
             "package_identity_file": "cuvs-java.release-package-identity.json"

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -536,12 +536,12 @@ jobs:
       artifact-name: "libcuvs_c_${{ matrix.CUDA_VER }}_${{ matrix.ARCH }}.tar.gz"
       file_to_upload: |
         libcuvs_c.tar.gz
-        libcuvs_c.release-package.json
+        libcuvs_c.release-package-identity.json
       release-catalog-config: >-
         {
           "artifact_type": "custom",
           "release_catalog_key": "archive:libcuvs-c",
-          "package_file": "libcuvs_c.release-package.json",
+          "package_identity_file": "libcuvs_c.release-package-identity.json",
           "artifacts": [{"path": "libcuvs_c.tar.gz"}]
         }
       sha: ${{ inputs.sha }}
@@ -613,7 +613,7 @@ jobs:
           "artifact_type": "custom",
           "release_catalog_key": "maven:cuvs-java",
           "output_directory": "java/cuvs-java/target",
-          "package_file": "cuvs-java.release-package.json",
+          "package_identity_file": "cuvs-java.release-package-identity.json",
           "artifacts": [{"path": "cuvs-java-*-x86_64-cuda*.jar"}]
         }
   rust-build-matrix:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -440,7 +440,7 @@ jobs:
       packages: read
       pull-requests: read
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-build.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-build.yaml@codex/release-build-output-manifests
     with:
       build_type: pull-request
       build-datetime: ${{ needs.build-details.outputs.build-datetime }}
@@ -482,7 +482,7 @@ jobs:
       packages: read
       pull-requests: read
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@codex/release-build-output-manifests
     with:
       build_type: pull-request
       build-datetime: ${{ needs.build-details.outputs.build-datetime }}
@@ -704,7 +704,7 @@ jobs:
       packages: read
       pull-requests: read
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@codex/release-build-output-manifests
     with:
       build_type: pull-request
       build-datetime: ${{ needs.build-details.outputs.build-datetime }}
@@ -723,7 +723,7 @@ jobs:
       packages: read
       pull-requests: read
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@codex/release-build-output-manifests
     with:
       build_type: pull-request
       build-datetime: ${{ needs.build-details.outputs.build-datetime }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -539,10 +539,11 @@ jobs:
         libcuvs_c.release-package-identity.json
       release-catalog-config: >-
         {
-          "artifact_type": "custom",
           "release_catalog_key": "archive:libcuvs-c",
-          "package_identity_file": "libcuvs_c.release-package-identity.json",
-          "artifacts": [{"path": "libcuvs_c.tar.gz"}]
+          "artifacts": [{
+            "path": "libcuvs_c.tar.gz",
+            "package_identity_file": "libcuvs_c.release-package-identity.json"
+          }]
         }
       sha: ${{ inputs.sha }}
   rocky8-clib-tests-matrix:
@@ -610,11 +611,12 @@ jobs:
       file_to_upload: "java/cuvs-java/target/"
       release-catalog-config: >-
         {
-          "artifact_type": "custom",
           "release_catalog_key": "maven:cuvs-java",
           "output_directory": "java/cuvs-java/target",
-          "package_identity_file": "cuvs-java.release-package-identity.json",
-          "artifacts": [{"path": "cuvs-java-*-x86_64-cuda*.jar"}]
+          "artifacts": [{
+            "path": "cuvs-java-*-x86_64-cuda*.jar",
+            "package_identity_file": "cuvs-java.release-package-identity.json"
+          }]
         }
   rust-build-matrix:
     needs: [conda-cpp-build, changed-files]

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -539,11 +539,10 @@ jobs:
         libcuvs_c.release-package-identity.json
       release-catalog-config: >-
         {
-          "artifact_type": "custom",
           "release_catalog_key": "archive:libcuvs-c",
-          "package_identity_file": "libcuvs_c.release-package-identity.json",
           "artifacts": [{
-            "path": "libcuvs_c.tar.gz"
+            "path": "libcuvs_c.tar.gz",
+            "package_identity_file": "libcuvs_c.release-package-identity.json"
           }]
         }
       sha: ${{ inputs.sha }}
@@ -612,12 +611,11 @@ jobs:
       file_to_upload: "java/cuvs-java/target/"
       release-catalog-config: >-
         {
-          "artifact_type": "custom",
           "release_catalog_key": "maven:cuvs-java",
-          "output_directory": "java/cuvs-java/target",
-          "package_identity_file": "cuvs-java.release-package-identity.json",
+          "artifact_directory": "java/cuvs-java/target",
           "artifacts": [{
-            "path": "cuvs-java-*-x86_64-cuda*.jar"
+            "path": "cuvs-java-*-x86_64-cuda*.jar",
+            "package_identity_file": "cuvs-java.release-package-identity.json"
           }]
         }
   rust-build-matrix:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -404,8 +404,6 @@ jobs:
       build_type: pull-request
       node_type: cpu16
       script: ci/build_cpp.sh
-      release-build-output: true
-      release-unit: conda:cuvs-cpp
   conda-cpp-tests:
     needs: [conda-cpp-build, changed-files]
     permissions:
@@ -446,8 +444,6 @@ jobs:
     with:
       build_type: pull-request
       script: ci/build_python.sh
-      release-build-output: true
-      release-unit: conda:cuvs-python
       # Build a conda package for each CUDA x ARCH x minimum supported Python version
       matrix_filter: group_by({CUDA_VER, ARCH}) | map(min_by(.PY_VER | split(".") | map(tonumber)))
   conda-python-tests:
@@ -666,8 +662,6 @@ jobs:
       matrix_filter: group_by([.ARCH, (.CUDA_VER|split(".")|map(tonumber)|.[0])]) | map(max_by(.PY_VER|split(".")|map(tonumber)))
       package-name: libcuvs
       package-type: cpp
-      release-build-output: true
-      release-unit: wheel:libcuvs
   wheel-build-cuvs:
     needs: wheel-build-libcuvs
     permissions:
@@ -684,8 +678,6 @@ jobs:
       script: ci/build_wheel_cuvs.sh
       package-name: cuvs
       package-type: python
-      release-build-output: true
-      release-unit: wheel:cuvs
       # Build a wheel for each CUDA x ARCH x minimum supported Python version
       matrix_filter: group_by({CUDA_VER, ARCH}) | map(min_by(.PY_VER | split(".") | map(tonumber)))
   wheel-tests-cuvs:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -399,11 +399,13 @@ jobs:
       packages: read
       pull-requests: read
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-build.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-build.yaml@codex/release-build-output-manifests
     with:
       build_type: pull-request
       node_type: cpu16
       script: ci/build_cpp.sh
+      release-build-output: true
+      release-unit: conda:cuvs-cpp
   conda-cpp-tests:
     needs: [conda-cpp-build, changed-files]
     permissions:
@@ -440,10 +442,12 @@ jobs:
       packages: read
       pull-requests: read
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@codex/release-build-output-manifests
     with:
       build_type: pull-request
       script: ci/build_python.sh
+      release-build-output: true
+      release-unit: conda:cuvs-python
       # Build a conda package for each CUDA x ARCH x minimum supported Python version
       matrix_filter: group_by({CUDA_VER, ARCH}) | map(min_by(.PY_VER | split(".") | map(tonumber)))
   conda-python-tests:
@@ -477,7 +481,7 @@ jobs:
       packages: read
       pull-requests: read
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@codex/release-build-output-manifests
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.rocky8-clib-standalone-build-matrix.outputs.matrix) }}
@@ -490,7 +494,14 @@ jobs:
       requires_license_builder: true
       script: "ci/build_standalone_c.sh --build-tests"
       artifact-name: "libcuvs_c_${{ matrix.CUDA_VER }}_${{ matrix.ARCH }}.tar.gz"
-      file_to_upload: "libcuvs_c.tar.gz"
+      file_to_upload: |
+        libcuvs_c.tar.gz
+        libcuvs_c.release-package.json
+      release-build-output: true
+      release-output-directory: .
+      release-unit: archive:libcuvs-c
+      release-package-file: libcuvs_c.release-package.json
+      release-artifacts: '[{"path":"libcuvs_c.tar.gz"}]'
       sha: ${{ inputs.sha }}
   rocky8-clib-tests-matrix:
     needs: [rocky8-clib-standalone-build, changed-files]
@@ -541,7 +552,7 @@ jobs:
       packages: read
       pull-requests: read
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@codex/release-build-output-manifests
     # Artifacts are not published from these jobs, so it's safe to run for multiple CUDA versions.
     # If these jobs start producing artifacts, the names will have to differentiate between CUDA versions.
     strategy:
@@ -555,6 +566,11 @@ jobs:
       script: "ci/test_java.sh"
       artifact-name: "cuvs-java-cuda${{ matrix.CUDA_VER }}"
       file_to_upload: "java/cuvs-java/target/"
+      release-build-output: true
+      release-output-directory: java/cuvs-java/target
+      release-unit: maven:cuvs-java
+      release-package-file: cuvs-java.release-package.json
+      release-artifacts: '[{"path":"cuvs-java-*-x86_64-cuda*.jar"}]'
   rust-build-matrix:
     needs: [conda-cpp-build, changed-files]
     permissions:
@@ -641,7 +657,7 @@ jobs:
       packages: read
       pull-requests: read
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@codex/release-build-output-manifests
     with:
       build_type: pull-request
       node_type: cpu16
@@ -650,6 +666,8 @@ jobs:
       matrix_filter: group_by([.ARCH, (.CUDA_VER|split(".")|map(tonumber)|.[0])]) | map(max_by(.PY_VER|split(".")|map(tonumber)))
       package-name: libcuvs
       package-type: cpp
+      release-build-output: true
+      release-unit: wheel:libcuvs
   wheel-build-cuvs:
     needs: wheel-build-libcuvs
     permissions:
@@ -659,13 +677,15 @@ jobs:
       packages: read
       pull-requests: read
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@codex/release-build-output-manifests
     with:
       build_type: pull-request
       node_type: cpu8
       script: ci/build_wheel_cuvs.sh
       package-name: cuvs
       package-type: python
+      release-build-output: true
+      release-unit: wheel:cuvs
       # Build a wheel for each CUDA x ARCH x minimum supported Python version
       matrix_filter: group_by({CUDA_VER, ARCH}) | map(min_by(.PY_VER | split(".") | map(tonumber)))
   wheel-tests-cuvs:

--- a/ci/build_java.sh
+++ b/ci/build_java.sh
@@ -63,7 +63,7 @@ if [[ "${EXITCODE}" -eq 0 ]]; then
   jq -n \
     --arg version "${JAVA_PACKAGE_VERSION}" \
     '{ecosystem: "maven", name: "com.nvidia.cuvs:cuvs-java", version: $version}' \
-    >java/cuvs-java/target/cuvs-java.release-package.json
+    >java/cuvs-java/target/cuvs-java.release-package-identity.json
 fi
 
 sccache --show-adv-stats

--- a/ci/build_java.sh
+++ b/ci/build_java.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 set -euo pipefail
@@ -57,6 +57,14 @@ RAPIDS_CUDA_MAJOR="${RAPIDS_CUDA_VERSION%%.*}"
 export RAPIDS_CUDA_MAJOR
 
 bash ./build.sh java "${EXTRA_BUILD_ARGS[@]}"
+
+if [[ "${EXITCODE}" -eq 0 ]]; then
+  JAVA_PACKAGE_VERSION="$(sed -n 's/.*<version>\([^<]*\)<\/version>.*/\1/p' java/cuvs-java/pom.xml | head -n 1)"
+  jq -n \
+    --arg version "${JAVA_PACKAGE_VERSION}" \
+    '{ecosystem: "maven", name: "com.nvidia.cuvs:cuvs-java", version: $version}' \
+    >java/cuvs-java/target/cuvs-java.release-package.json
+fi
 
 sccache --show-adv-stats
 sccache --stop-server >/dev/null 2>&1 || true

--- a/ci/build_standalone_c.sh
+++ b/ci/build_standalone_c.sh
@@ -99,3 +99,7 @@ license-builder . --output-json c/build/install/licenses.json --output-txt c/bui
 rapids-logger "Begin c tarball creation"
 tar czf libcuvs_c.tar.gz -C c/build/install/ .
 ls -lh libcuvs_c.tar.gz
+jq -n \
+      --arg version "${RAPIDS_PACKAGE_VERSION}" \
+      '{ecosystem: "archive", name: "libcuvs-c", version: $version}' \
+      >libcuvs_c.release-package.json

--- a/ci/build_standalone_c.sh
+++ b/ci/build_standalone_c.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 set -euo pipefail
@@ -99,3 +99,7 @@ license-builder . --output-json c/build/install/licenses.json --output-txt c/bui
 rapids-logger "Begin c tarball creation"
 tar czf libcuvs_c.tar.gz -C c/build/install/ .
 ls -lh libcuvs_c.tar.gz
+jq -n \
+      --arg version "${RAPIDS_PACKAGE_VERSION}" \
+      '{ecosystem: "archive", name: "libcuvs-c", version: $version}' \
+      >libcuvs_c.release-package.json

--- a/ci/build_standalone_c.sh
+++ b/ci/build_standalone_c.sh
@@ -102,4 +102,4 @@ ls -lh libcuvs_c.tar.gz
 jq -n \
       --arg version "${RAPIDS_PACKAGE_VERSION}" \
       '{ecosystem: "archive", name: "libcuvs-c", version: $version}' \
-      >libcuvs_c.release-package.json
+      >libcuvs_c.release-package-identity.json

--- a/ci/build_wheel.sh
+++ b/ci/build_wheel.sh
@@ -30,8 +30,12 @@ source rapids-init-pip
 export SCCACHE_S3_PREPROCESSOR_CACHE_KEY_PREFIX="${package_name}/${RAPIDS_CONDA_ARCH}/cuda${RAPIDS_CUDA_VERSION%%.*}/wheel/preprocessor-cache"
 export SCCACHE_S3_USE_PREPROCESSOR_CACHE_MODE=true
 
-RAPIDS_VERSION_SUFFIX=".post${RAPIDS_DATETIME_STRING}" \
+if [[ "${RAPIDS_RELEASE_CANDIDATE:-false}" == "true" ]]; then
   rapids-generate-version > ./VERSION
+else
+  RAPIDS_VERSION_SUFFIX=".post${RAPIDS_DATETIME_STRING}" \
+    rapids-generate-version > ./VERSION
+fi
 
 cd "${package_dir}"
 


### PR DESCRIPTION
**Posted by Codex (GPT-5) on behalf of [@msarahan](https://github.com/msarahan). This pull request description is LLM-generated; readers should treat its content accordingly.**

## Summary

- enroll the four matrixed standalone `libcuvs_c` archive producers in release catalog generation;
- enroll the two CUDA-classified Java bundle producers;
- use explicit release catalog keys for the independently managed artifact sets: `archive:libcuvs-c` and `maven:cuvs-java`;
- emit exact build-time package identity JSON for each non-parseable bundle and associate each `package_identity_file` with the artifact descriptor it describes; and
- apply the enrollment consistently in both `build.yaml` and `pr.yaml`.

The Java producers set `artifact_directory` to `java/cuvs-java/target`; the archive producers use the default job working directory. Each selected artifact and identity path is relative to its artifact directory.

Standard Conda and wheel workflows remain on `shared-workflows@main`. Their default release catalog companions are owned by [`rapidsai/shared-workflows#609`](https://github.com/rapidsai/shared-workflows/pull/609) and do not require repository-specific changes here.

The two explicit producer call sites temporarily target `shared-workflows@codex/release-build-output-manifests` so this draft remains testable before #609 merges. They must return to `@main` after #609 lands and before this PR merges. The branch name is a temporary Git reference; the workflow interface and generated artifacts use the current release catalog terminology.

## Expected coverage

- four standalone `libcuvs_c` archive companions;
- two Java companions.

Each source artifact receives a `release-catalog-<source-artifact-name>` companion containing one enveloped `release-catalog-entries.json` and the collected evidence.

## Evidence semantics

These producers do not supply dependency SBOMs. Their companions therefore contain `generated-identity` SPDX envelopes identifying each primary artifact and checksum. They must not be reported as producer-supplied dependency SBOMs or dependency coverage.

## Validation

- all four explicit cuVS release catalog configurations pass the current shared-actions validator;
- changed-file pre-commit passes, including yamllint and zizmor; and
- `git diff --check` passes.

Tracks [`rapidsai/build-infra#381`](https://github.com/rapidsai/build-infra/issues/381), [`rapidsai/shared-workflows#609`](https://github.com/rapidsai/shared-workflows/pull/609), and [`rapidsai/shared-actions#136`](https://github.com/rapidsai/shared-actions/pull/136).
