### PR TITLE
fix(update-version): don't blanket replace the word main with release branch in README.md

### DIFF
--- a/ci/release/update-version.sh
+++ b/ci/release/update-version.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 ########################
 # CUVS Version Updater #
@@ -140,8 +140,9 @@ if [[ "${RUN_CONTEXT}" == "main" ]]; then
 elif [[ "${RUN_CONTEXT}" == "release" ]]; then
   # In release context, use release branch for documentation links (word boundaries to avoid partial matches)
   sed_runner "/rapidsai\\/cuvs/ s|\\bmain\\b|release/${NEXT_SHORT_TAG}|g" fern/pages/developer_guide.md
-  sed_runner "s|\\bmain\\b|release/${NEXT_SHORT_TAG}|g" README.md
-  # Only update the GitHub URL, not the main() function
+  # Only update GitHub URL paths, not code (e.g. fn main() in Rust examples)
+  sed_runner "s|/cuvs/blob/main/|/cuvs/blob/release/${NEXT_SHORT_TAG}/|g" README.md
+  sed_runner "s|/cuvs/tree/main/|/cuvs/tree/release/${NEXT_SHORT_TAG}/|g" README.md
   sed_runner "s|/cuvs/blob/\\bmain\\b/|/cuvs/blob/release/${NEXT_SHORT_TAG}/|g" python/cuvs_bench/cuvs_bench/plot/__main__.py
 fi
 


### PR DESCRIPTION
Hotfix for 26.08 release.

2 weeks ago this commit NVIDIA/cuvs@dd84ab5#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R159-R167 added some helpful new documentation to the `README.md` in cuvs.

It's a rust example and so it uses fn main() in the example code. update-version.sh looks everywhere for branch references that should be updated to release/26.08 and it did that, which then broke the rust doctests.

So, we fix update-version to be a little more measured in its replacements, then we have to cut a hotfix release on top of 26.08 for cuvs to get the rust artifacts published.

This PR is for making sure this commit also lands in `main` so this doesn't happen again.

xref #2420 
