### PR TITLE
Standalone tarball build using Docker

### DIFF
--- a/Dockerfile.standalone
+++ b/Dockerfile.standalone
@@ -1,0 +1,54 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Environment and runner for the standalone C build (see ci/build_standalone_c.sh).
+# Build args: CUDA_VERSION (default 13.0), PYTHON_VERSION (default 3.11).
+#
+# Quick run: docker run -v $(pwd):/workspace -v $(pwd)/build:/build <image> [--build-tests]
+
+ARG CUDA_VERSION=13.0
+ARG PYTHON_VERSION=3.11
+FROM rapidsai/ci-wheel:26.04-cuda${CUDA_VERSION}-rockylinux8-py${PYTHON_VERSION}
+
+ARG NINJA_VERSION=v1.13.1
+
+# System packages required by ci/build_standalone_c.sh
+RUN dnf install -y \
+    patch \
+    tar \
+    unzip \
+    wget \
+    && dnf clean all
+
+# Install ninja (architecture-aware)
+RUN set -euo pipefail; \
+    if ! command -V ninja >/dev/null 2>&1; then \
+        case "$(uname -m)" in \
+            x86_64) \
+                wget --no-hsts -q -O /tmp/ninja-linux.zip "https://github.com/ninja-build/ninja/releases/download/${NINJA_VERSION}/ninja-linux.zip"; \
+                ;; \
+            aarch64) \
+                wget --no-hsts -q -O /tmp/ninja-linux.zip "https://github.com/ninja-build/ninja/releases/download/${NINJA_VERSION}/ninja-linux-aarch64.zip"; \
+                ;; \
+            *) \
+                echo "Unrecognized platform '$(uname -m)'" >&2; exit 1; \
+                ;; \
+        esac; \
+        unzip -d /usr/bin /tmp/ninja-linux.zip; \
+        chmod +x /usr/bin/ninja; \
+        rm /tmp/ninja-linux.zip; \
+    fi
+
+# CMake; sccache/date are configured at runtime by ci/build_standalone_c.sh
+RUN rapids-pip-retry install cmake \
+    && pyenv rehash
+
+# Output directory for the standalone archive. Bind-mount a host folder here
+# (e.g. -v $(pwd)/build:/build) so libcuvs_c.tar.gz is written to the host.
+ENV BUILD_OUTPUT_DIR=/build
+
+# Run from repo root; the repo is expected to be bind-mounted at /workspace.
+WORKDIR /workspace
+
+# Run the build script, then copy the standalone tarball into the mounted output dir.
+ENTRYPOINT ["/bin/bash", "-c", "ci/build_standalone_c.sh \"$@\" && cp -v libcuvs_c.tar.gz \"$BUILD_OUTPUT_DIR/\"", "--"]

--- a/build.sh
+++ b/build.sh
@@ -19,7 +19,7 @@ ARGS=$*
 # scripts, and that this script resides in the repo dir!
 REPODIR=$(cd "$(dirname "$0")"; pwd)
 
-VALIDARGS="clean libcuvs python rust go java docs tests bench-ann examples --uninstall  -v -g -n --allgpuarch --no-mg --mnmg-tests --no-cpu --cpu-only --no-shared-libs --no-nvtx --show_depr_warn --incl-cache-stats --time -h --run-java-tests"
+VALIDARGS="clean libcuvs python rust go java docs tests bench-ann examples tarball --uninstall  -v -g -n --allgpuarch --no-mg --mnmg-tests --no-cpu --cpu-only --no-shared-libs --no-nvtx --show_depr_warn --incl-cache-stats --time -h --run-java-tests"
 HELP="$0 [<target> ...] [<flag> ...] [--cmake-args=\"<args>\"] [--cache-tool=<tool>] [--limit-tests=<targets>] [--limit-bench-ann=<targets>] [--build-metrics=<filename>]
  where <target> is:
    clean            - remove all existing build artifacts and configuration (start over)
@@ -33,6 +33,7 @@ HELP="$0 [<target> ...] [<flag> ...] [--cmake-args=\"<args>\"] [--cache-tool=<to
    tests            - build the tests
    bench-ann        - build end-to-end ann benchmarks
    examples         - build the examples
+   tarball          - create the standalone C library tarball from c/build/install
 
  and <flag> is:
    -v                          - verbose build mode
@@ -573,4 +574,12 @@ if hasArg examples; then
     pushd "${REPODIR}"/examples
     ./build.sh
     popd
+fi
+
+################################################################################
+# Create the standalone C library tarball (if requested)
+
+if hasArg tarball; then
+    tar czf "${REPODIR}/libcuvs_c.tar.gz" -C "${REPODIR}/c/build/install" .
+    ls -lh "${REPODIR}/libcuvs_c.tar.gz"
 fi

--- a/ci/build_standalone_c.sh
+++ b/ci/build_standalone_c.sh
@@ -4,6 +4,9 @@
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
 TOOLSET_VERSION=14
 NINJA_VERSION=v1.13.1
 
@@ -97,5 +100,4 @@ rapids-pip-retry install git+https://github.com/rapidsai/spdx-license-builder.gi
 license-builder . --output-json c/build/install/licenses.json --output-txt c/build/install/LICENSE
 
 rapids-logger "Begin c tarball creation"
-tar czf libcuvs_c.tar.gz -C c/build/install/ .
-ls -lh libcuvs_c.tar.gz
+"${REPO_ROOT}/build.sh" tarball


### PR DESCRIPTION
This is based on @msarahan's PoC to use Docker for building the tarball in a more portable way. This PR moves the script logic around and puts the Dockerfile in the root so that the tarball can be built directly with `build.sh`. 