### PR TITLE
doc: remove RAPIDS logo image from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# <div align="left"><img src="https://rapids.ai/assets/images/rapids_logo.png" width="90px"/>&nbsp;cuVS: Vector Search and Clustering on the GPU</div>
+# cuVS: Vector Search and Clustering on the GPU
 
 
 ## Contents


### PR DESCRIPTION
## Summary

Removes the RAPIDS logo `<img>` from the top of `README.md`, as requested in #2295.

## Scope note

#2295 also asks to replace other mentions of "RAPIDS" with "NVIDIA" across the codebase. I audited every remaining `RAPIDS` occurrence (README, fern docs, cmake, CI scripts, env vars) and left them as-is, because they refer to the actual, current names of separate things cuVS depends on or documents rather than to cuVS's own branding:

- `RAPIDS_DATASET_ROOT_DIR` — a real environment variable read by `cuvs_bench` code; renaming it in docs only would make the docs wrong.
- "RAPIDS RAFT" / `github.com/rapidsai/raft` — the real name of the separate library cuVS is built on.
- "RAPIDS Memory Manager (RMM)" — the real, official name of another dependency.
- "RAPIDS Community" (`rapids.ai/community.html`), the RAPIDS release schedule, and "RAPIDS pre-commit hooks" — real external resources with valid links, which the issue also says not to remove.

Renaming any of these would be factually incorrect. Happy to take a pass at a broader rebrand if maintainers want to scope that differently — flagging here rather than guessing.

Fixes #2295 (logo portion)

🤖 Generated with [Claude Code](https://claude.com/claude-code)