### PR TITLE
fix: anonymous struct detection uses wrong spelling marker

### DIFF
--- a/ci/check_c_abi/check_c_abi/abi.py
+++ b/ci/check_c_abi/check_c_abi/abi.py
@@ -21,10 +21,10 @@ except ImportError:
 
 
 def _is_unnamed_struct(cursor: clang.cindex.Cursor) -> bool:
+    # Anonymous record declarations have no tag, so libclang reports an empty spelling.
     return (
         cursor.kind == clang.cindex.CursorKind.STRUCT_DECL
-        and cursor.spelling.startswith("struct ")
-        and "unnamed " in cursor.spelling
+        and not cursor.spelling
     )
 
 


### PR DESCRIPTION
This PR addresses the following issue in `ci/check_c_abi/check_c_abi/abi.py`: anonymous struct detection uses wrong spelling marker.

## Changes
- `ci/check_c_abi/check_c_abi/abi.py`: anonymous struct detection uses wrong spelling marker.

## Details
```diff
--- a/ci/check_c_abi/check_c_abi/abi.py
+++ b/ci/check_c_abi/check_c_abi/abi.py
@@ -1,6 +1,6 @@
-def _is_unnamed_struct(cursor: clang.cindex.Cursor) -> bool:
-    return (
-        cursor.kind == clang.cindex.CursorKind.STRUCT_DECL
-        and cursor.spelling.startswith("struct ")
-        and "unnamed " in cursor.spelling
-    )
+def _is_unnamed_struct(cursor: clang.cindex.Cursor) -> bool:
+    # Anonymous record declarations have no tag, so libclang reports an empty spelling.
+    return (
+        cursor.kind == clang.cindex.CursorKind.STRUCT_DECL
+        and not cursor.spelling
+    )
```

## Tests
- `ci/check_c_abi/tests/test_abi.py`

```diff
--- /dev/null
+++ b/ci/check_c_abi/tests/test_abi.py
@@ -0,0 +1,53 @@
+import types
+
+import pytest
+
+import clang.cindex
+
+from check_c_abi.abi import _is_unnamed_struct, Abi
+
+
+def _make_cursor(kind, spelling):
+    return types.SimpleNamespace(kind=kind, spelling=spelling)
+
+
+def test_is_unnamed_struct_detects_empty_spelling():
+    cursor = _make_cursor(clang.cindex.CursorKind.STRUCT_DECL, "")
+    assert _is_unnamed_struct(cursor) is True
+
+
+def test_is_unnamed_struct_rejects_named_struct():
+    cursor = _make_cursor(clang.cindex.CursorKind.STRUCT_DECL, "my_struct")
+    assert _is_unnamed_struct(cursor) is False
+
+
+def test_is_unnamed_struct_rejects_non_struct():
+    cursor = _make_cursor(clang.cindex.CursorKind.FUNCTION_DECL, "")
+    assert _is_unnamed_struct(cursor) is False
+
+
+def test_abi_skips_and_renames_anonymous_structs(tmp_path):
+    root = tmp_path / "include"
+    root.mkdir()
+    header = root / "all.h"
+    header.write_text(
+        """
+struct { int a; } unnamed_global;
+typedef struct { int b; } named_t;
+struct real_struct { int c; };
+"""
+    )
+
+    abi = Abi.from_include_path(root, "all.h")
+    struct_names = {s.name for s in abi.structs}
+
+    assert len(abi.structs) == 2
+    assert "" not in struct_names
+    assert "named_t" in struct_names
+    assert "real_struct" in struct_names
+    named = next(s for s in abi.structs if s.name == "named_t")
+    assert ("int", "b") in named.members
```