### PR TITLE
fix: Reorder imports to follow stdlib-first convention

### DIFF
--- a/ci/check_c_abi/check_c_abi/abi.py
+++ b/ci/check_c_abi/check_c_abi/abi.py
@@ -3,14 +3,13 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-import msgspec
 from itertools import zip_longest
+import os
 import pathlib
 from typing import Generator, Optional, Self
-import os
-
 
 import clang.cindex
+import msgspec
 
 try:
     from termcolor import colored


### PR DESCRIPTION
This PR addresses the following issue in `ci/check_c_abi/check_c_abi/abi.py`: Reorder imports to follow stdlib-first convention.

## Changes
- `ci/check_c_abi/check_c_abi/abi.py`: Reorder imports to follow stdlib-first convention.

## Details
```diff
--- a/ci/check_c_abi/check_c_abi/abi.py
+++ b/ci/check_c_abi/check_c_abi/abi.py
@@ -1,18 +1,17 @@
-import msgspec
-from itertools import zip_longest
-import pathlib
-from typing import Generator, Optional, Self
-import os
-
-
-import clang.cindex
-
-try:
-    from termcolor import colored
-except ImportError:
-
-    def colored(text, *args, **kwargs):
-        return text
-
-
-def _is_unnamed_struct(cursor: clang.cindex.Cursor) -> bool:
+from itertools import zip_longest
+import os
+import pathlib
+from typing import Generator, Optional, Self
+
+import clang.cindex
+import msgspec
+
+try:
+    from termcolor import colored
+except ImportError:
+
+    def colored(text, *args, **kwargs):
+        return text
+
+
+def _is_unnamed_struct(cursor: clang.cindex.Cursor) -> bool:
```

## Tests

> Let me know if you want tests added for this fix or not.