### PR TITLE
Make run_spotless.sh more verbose and strict

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -100,6 +100,7 @@ repos:
         files: ^java/(cuvs-java|cuvs-lucene)/([^/]+/)?src/.*\.java$
         exclude: .*/panama/.*
         language: script
+        verbose: true
       - id: clang-format-with-cmake-placeholders
         name: clang-format-with-cmake-placeholders
         entry: python3 ci/checks/clang_format_with_cmake_placeholders.py

--- a/ci/checks/run_spotless.sh
+++ b/ci/checks/run_spotless.sh
@@ -5,19 +5,36 @@
 # pre-commit hook wrapper that runs 'spotless:apply' to format the Java sources of every Maven
 # project under java/.
 #
-# Most cuvs contributors do not work on the Java client and do not have Maven installed. For them
-# (running outside CI without Maven) this skips gracefully, so that 'pre-commit run --all-files'
-# does not require every contributor to install Maven. In CI, Maven is expected to be available and
-# its absence is treated as an error.
+# Most cuvs contributors do not work on the Java client and do not have Maven installed. For them,
+# running 'pre-commit run --all-files' matches every Java source file in the repo regardless of
+# whether they touched any of it, so this skips gracefully when Maven is missing and there are no
+# actual local changes to Java sources. In CI, and for anyone who has actually modified Java
+# sources locally, Maven is expected to be available and its absence is treated as an error.
 
 set -euo pipefail
+
+# Keep these in sync with the spotless-fmt hook's 'files'/'exclude' entries in
+# .pre-commit-config.yaml.
+JAVA_SRC_PATTERN='^java/(cuvs-java|cuvs-lucene)/([^/]+/)?src/.*\.java$'
+JAVA_SRC_EXCLUDE='.*/panama/.*'
+
+java_sources_modified() {
+  git status --porcelain --untracked-files=all -- java/cuvs-java java/cuvs-lucene |
+    cut -c4- |
+    grep -Ev "${JAVA_SRC_EXCLUDE}" |
+    grep -Eq "${JAVA_SRC_PATTERN}"
+}
 
 if ! command -v mvn >/dev/null 2>&1; then
   if [ "${CI:-false}" = "true" ]; then
     echo "spotless-fmt: 'mvn' is required in CI but was not found on PATH." >&2
     exit 1
   fi
-  echo "spotless-fmt: skipping Java formatting ('mvn' not installed and not running in CI)." >&2
+  if java_sources_modified; then
+    echo "spotless-fmt: 'mvn' is required to format modified Java sources but was not found on PATH." >&2
+    exit 1
+  fi
+  echo "spotless-fmt: 'mvn' was not found on PATH and no Java sources were modified, skipping Java formatting." >&2
   exit 0
 fi
 


### PR DESCRIPTION
Some developers ran into issues with spotless-fmt skipping formatting silently on their local machines and then failing in CI. This PR now fails if there are any modified Java files and prints a warning if there are no changed Java files and Maven is not present.

Follow-up for #2361