### PR TITLE
Use `rtcx` ELF embedding for JIT LTO fragments

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -155,14 +155,20 @@ if(NOT BUILD_CPU_ONLY)
   # * enable the CMake CUDA language
   # * set other CUDA compilation flags
   rapids_find_package(
-    CUDAToolkit REQUIRED BUILD_EXPORT_SET cuvs-exports INSTALL_EXPORT_SET cuvs-exports
+    CUDAToolkit REQUIRED
+    BUILD_EXPORT_SET cuvs-exports
+    INSTALL_EXPORT_SET cuvs-exports
   )
 else()
   add_compile_definitions(BUILD_CPU_ONLY)
 endif()
 
 if(NOT DISABLE_OPENMP)
-  rapids_find_package(OpenMP REQUIRED BUILD_EXPORT_SET cuvs-exports INSTALL_EXPORT_SET cuvs-exports)
+  rapids_find_package(
+    OpenMP REQUIRED
+    BUILD_EXPORT_SET cuvs-exports
+    INSTALL_EXPORT_SET cuvs-exports
+  )
   if(OPENMP_FOUND)
     message(VERBOSE "cuVS: OpenMP found in ${OpenMP_CXX_INCLUDE_DIRS}")
   endif()
@@ -1513,7 +1519,11 @@ if(NOT BUILD_CPU_ONLY)
   endif()
 
   if(BUILD_MG_ALGOS)
-    rapids_find_generate_module(NCCL HEADER_NAMES nccl.h LIBRARY_NAMES nccl)
+    rapids_find_generate_module(
+      NCCL
+      HEADER_NAMES nccl.h
+      LIBRARY_NAMES nccl
+    )
     find_package(NCCL REQUIRED)
     target_link_libraries(cuvs_objs PUBLIC $<BUILD_LOCAL_INTERFACE:NCCL::NCCL>)
   endif()

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -155,20 +155,14 @@ if(NOT BUILD_CPU_ONLY)
   # * enable the CMake CUDA language
   # * set other CUDA compilation flags
   rapids_find_package(
-    CUDAToolkit REQUIRED
-    BUILD_EXPORT_SET cuvs-exports
-    INSTALL_EXPORT_SET cuvs-exports
+    CUDAToolkit REQUIRED BUILD_EXPORT_SET cuvs-exports INSTALL_EXPORT_SET cuvs-exports
   )
 else()
   add_compile_definitions(BUILD_CPU_ONLY)
 endif()
 
 if(NOT DISABLE_OPENMP)
-  rapids_find_package(
-    OpenMP REQUIRED
-    BUILD_EXPORT_SET cuvs-exports
-    INSTALL_EXPORT_SET cuvs-exports
-  )
+  rapids_find_package(OpenMP REQUIRED BUILD_EXPORT_SET cuvs-exports INSTALL_EXPORT_SET cuvs-exports)
   if(OPENMP_FOUND)
     message(VERBOSE "cuVS: OpenMP found in ${OpenMP_CXX_INCLUDE_DIRS}")
   endif()
@@ -373,8 +367,7 @@ if(NOT BUILD_CPU_ONLY)
   block(PROPAGATE jit_lto_files)
   set(jit_lto_files)
   rtcx_jit_lto_embed_begin(
-    cuvs_jit_lto_fragments
-    OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/generated_kernels/jit_lto"
+    cuvs_jit_lto_fragments OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/generated_kernels/jit_lto"
   )
   set(CMAKE_CUDA_ARCHITECTURES ${JIT_LTO_TARGET_ARCHITECTURE})
   set(neighbors_ns "cuvs::neighbors::detail")
@@ -1520,11 +1513,7 @@ if(NOT BUILD_CPU_ONLY)
   endif()
 
   if(BUILD_MG_ALGOS)
-    rapids_find_generate_module(
-      NCCL
-      HEADER_NAMES nccl.h
-      LIBRARY_NAMES nccl
-    )
+    rapids_find_generate_module(NCCL HEADER_NAMES nccl.h LIBRARY_NAMES nccl)
     find_package(NCCL REQUIRED)
     target_link_libraries(cuvs_objs PUBLIC $<BUILD_LOCAL_INTERFACE:NCCL::NCCL>)
   endif()

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -369,8 +369,13 @@ if(NOT BUILD_CPU_ONLY)
     jit_lto_kernel_usage_requirements INTERFACE rmm::rmm raft::raft CCCL::CCCL cuco::cuco
   )
 
+  enable_language(ASM)
   block(PROPAGATE jit_lto_files)
   set(jit_lto_files)
+  rtcx_jit_lto_embed_begin(
+    cuvs_jit_lto_fragments
+    OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/generated_kernels/jit_lto"
+  )
   set(CMAKE_CUDA_ARCHITECTURES ${JIT_LTO_TARGET_ARCHITECTURE})
   set(neighbors_ns "cuvs::neighbors::detail")
   generate_jit_lto_kernels(
@@ -1150,6 +1155,7 @@ if(NOT BUILD_CPU_ONLY)
       "${CMAKE_CURRENT_BINARY_DIR}/generated_kernels/distance/pairwise_matrix/compute_distance_epilog_rbf"
     KERNEL_LINK_LIBRARIES jit_lto_kernel_usage_requirements
   )
+  rtcx_jit_lto_embed_finalize(cuvs_jit_lto_fragments SOURCE_LIST jit_lto_files)
   endblock()
 
   # Note that this matrix contains an `arch_includes` placeholder, since we don't currently have a

--- a/cpp/cmake/thirdparty/get_rtcx.cmake
+++ b/cpp/cmake/thirdparty/get_rtcx.cmake
@@ -22,8 +22,8 @@ function(find_and_configure_rtcx VERSION)
     BUILD_EXPORT_SET    cuvs-static-exports
     INSTALL_EXPORT_SET  cuvs-static-exports
     CPM_ARGS
-    GIT_REPOSITORY https://github.com/rapidsai/librtcx
-    GIT_TAG a9f63f8cdd4b0b41a2d88a9f705576a61b4222ec
+    GIT_REPOSITORY https://github.com/divyegala/librtcx
+    GIT_TAG cuvs-elf
     GIT_SHALLOW FALSE
   )
 


### PR DESCRIPTION
This switches from using `bin2c` embedding of 1 TU per LTO-IR fragment to writing the LTO-IR binary using the assembler straight in the ELF.

Depends on https://github.com/rapidsai/librtcx/pull/16

These are single architecture benchmarks with `-j12` parallelism. We get closer to ~500s saved in build time as we decrease the parallelism.

| Work | Legacy main | ELF-backed |
|---|---:|---:|
| JIT fragment kernel objects | 1,548 | 1,548 |
| Fragment-kernel compiler time (sum) | 7,450.9s | 7,353.3s |
| Fragment-kernel wall span | 622.4s | 614.0s |
| Generated registration/wrapper compiles | 1,548 | 2 |
| Wrapper compiler time (sum) | 497.1s | 0.6s |
| Wrapper wall span | 55.0s | 0.55s |
