### PR TITLE
Optimize recall calculation and enhance CAGRA search features

### DIFF
--- a/cpp/bench/ann/src/common/benchmark.hpp
+++ b/cpp/bench/ann/src/common/benchmark.hpp
@@ -360,55 +360,56 @@ void bench_search(::benchmark::State& state,
     std::size_t match_count = 0;
     std::size_t total_count = 0;
 
-    // We go through the groundtruth with same stride as the benchmark loop.
-    size_t out_offset   = 0;
-    size_t batch_offset = (state.thread_index() * n_queries) % query_set_size;
-    // Avoid CPU oversubscription when parallelizing recall calculation loop
-    int num_recall_calculation_worker_threads =
-      std::thread::hardware_concurrency() / benchmark_n_threads - 1;  // -1 for the main thread
-    // ensure non-negative number of workers (possible if hardware_concurrency()
-    // does not return an expected value) by clamping to 0
-    if (num_recall_calculation_worker_threads < 0) { num_recall_calculation_worker_threads = 0; }
-    while (out_offset < rows) {
-      std::vector<std::thread> recall_calculation_workers;
-      recall_calculation_workers.reserve(num_recall_calculation_worker_threads);
-      std::vector<std::size_t> local_match_count(num_recall_calculation_worker_threads + 1);
-      std::vector<std::size_t> local_total_count(num_recall_calculation_worker_threads + 1);
-      int chunk_size =
-        n_queries / (num_recall_calculation_worker_threads + 1);  // +1 for the main thread
-      int remainder           = n_queries % (num_recall_calculation_worker_threads + 1);
-      auto recall_calculation = [&](int start, int end, int tid) -> void {
-        for (int i = start; i < end; ++i) {
-          size_t i_orig_idx = batch_offset + i;
-          size_t i_out_idx  = out_offset + i;
-          if (i_out_idx < rows) {
-            auto* candidates       = neighbors_host + i_out_idx * k;
-            auto [matching, total] = gt_maps->count_matches(i_orig_idx, candidates, k);
-            local_match_count[tid] += matching;
-            local_total_count[tid] += total;
-          }
-        }
-      };
-      // launch worker threads
-      int start = 0;
-      for (int tid = 0; tid < num_recall_calculation_worker_threads; tid++) {
-        int end = start + chunk_size;
-        if (tid < remainder) { ++end; }
-        recall_calculation_workers.emplace_back(recall_calculation, start, end, tid);
-        start = end;
-      }
-      // main thread works on last chunk
-      recall_calculation(start, n_queries, num_recall_calculation_worker_threads);
-      // join all worker threads
-      for (auto& worker : recall_calculation_workers) {
-        worker.join();
-      }
-      match_count += std::accumulate(local_match_count.begin(), local_match_count.end(), 0);
-      total_count += std::accumulate(local_total_count.begin(), local_total_count.end(), 0);
+    // Map result-buffer row -> original query index using the same stride as the
+    // timed search loop. Parallelize once over all `rows` (not once per search
+    // batch): when n_queries==1 the old per-batch spawn/join dominated wall time.
+    const size_t start_batch_offset = (state.thread_index() * n_queries) % query_set_size;
+    auto orig_query_idx             = [&](size_t i_out_idx) -> size_t {
+      const size_t batch_num  = i_out_idx / n_queries;
+      const size_t i_in_batch = i_out_idx % n_queries;
+      const size_t batch_offset =
+        (start_batch_offset + batch_num * queries_stride) % query_set_size;
+      return batch_offset + i_in_batch;
+    };
 
-      out_offset += n_queries;
-      batch_offset = (batch_offset + queries_stride) % query_set_size;
+    // Avoid CPU oversubscription when parallelizing recall calculation
+    int num_workers =
+      static_cast<int>(std::thread::hardware_concurrency()) / benchmark_n_threads;  // includes main
+    if (num_workers < 1) { num_workers = 1; }
+    // No benefit from more workers than rows
+    num_workers                  = std::min(num_workers, std::max(1, static_cast<int>(rows)));
+    const int num_helper_threads = num_workers - 1;
+
+    std::vector<std::thread> recall_workers;
+    recall_workers.reserve(num_helper_threads);
+    std::vector<std::size_t> local_match_count(num_workers, 0);
+    std::vector<std::size_t> local_total_count(num_workers, 0);
+
+    auto recall_range = [&](size_t start, size_t end, int tid) {
+      for (size_t i_out_idx = start; i_out_idx < end; ++i_out_idx) {
+        auto* candidates       = neighbors_host + i_out_idx * k;
+        auto [matching, total] = gt_maps->count_matches(orig_query_idx(i_out_idx), candidates, k);
+        local_match_count[tid] += matching;
+        local_total_count[tid] += total;
+      }
+    };
+
+    const size_t chunk_size = rows / static_cast<size_t>(num_workers);
+    const size_t remainder  = rows % static_cast<size_t>(num_workers);
+    size_t start            = 0;
+    for (int tid = 0; tid < num_helper_threads; ++tid) {
+      size_t end = start + chunk_size + (static_cast<size_t>(tid) < remainder ? 1 : 0);
+      recall_workers.emplace_back(recall_range, start, end, tid);
+      start = end;
     }
+    // main thread works on last chunk
+    recall_range(start, rows, num_helper_threads);
+    for (auto& worker : recall_workers) {
+      worker.join();
+    }
+    match_count = std::accumulate(local_match_count.begin(), local_match_count.end(), size_t{0});
+    total_count = std::accumulate(local_total_count.begin(), local_total_count.end(), size_t{0});
+
     double actual_recall = static_cast<double>(match_count) / static_cast<double>(total_count);
     /* NOTE: recall in the throughput mode & filtering
 

--- a/cpp/bench/ann/src/cuvs/cuvs_ann_bench_param_parser.h
+++ b/cpp/bench/ann/src/cuvs/cuvs_ann_bench_param_parser.h
@@ -489,6 +489,9 @@ void parse_search_param(const nlohmann::json& conf,
   if (conf.contains("thread_block_size")) {
     param.p.thread_block_size = conf.at("thread_block_size");
   }
+  if (conf.contains("hashmap_min_bitlen")) {
+    param.p.hashmap_min_bitlen = conf.at("hashmap_min_bitlen");
+  }
   if (conf.contains("algo")) {
     if (conf.at("algo") == "single_cta") {
       param.p.algo = cuvs::neighbors::cagra::search_algo::SINGLE_CTA;

--- a/cpp/include/cuvs/neighbors/cagra.hpp
+++ b/cpp/include/cuvs/neighbors/cagra.hpp
@@ -367,7 +367,7 @@ struct search_params : cuvs::neighbors::search_params {
   size_t thread_block_size = 0;
   /** Hashmap type. Auto selection when AUTO. */
   hash_mode hashmap_mode = hash_mode::AUTO;
-  /** Lower limit of hashmap bit length. More than 8. */
+  /** Lower limit of hashmap bit length. 0 selects the default; otherwise, 8 to 20. */
   size_t hashmap_min_bitlen = 0;
   /** Upper limit of hashmap fill rate. More than 0.1, less than 0.9.*/
   float hashmap_max_fill_rate = 0.5;

--- a/cpp/include/cuvs/neighbors/cagra.hpp
+++ b/cpp/include/cuvs/neighbors/cagra.hpp
@@ -356,8 +356,9 @@ struct search_params : cuvs::neighbors::search_params {
   /** Number of threads used to calculate a single distance. 4, 8, 16, or 32. */
   size_t team_size = 0;
 
-  /** Number of graph nodes to select as the starting point for the search in each iteration. aka
-   * search width?*/
+  /** Number of graph nodes to select as the starting point for the search in each iteration.
+   *  Auto select as ceil(itopk_size / graph_degree) when 0.
+   */
   size_t search_width = 1;
   /** Lower limit of search iterations. */
   size_t min_iterations = 0;

--- a/cpp/src/neighbors/detail/cagra/search_multi_cta.cuh
+++ b/cpp/src/neighbors/detail/cagra/search_multi_cta.cuh
@@ -117,13 +117,14 @@ struct search
   void set_params(raft::resources const& res, const search_params& params)
   {
     size_t global_itopk_size                = itopk_size;
+    size_t global_search_width              = search_width;
     constexpr unsigned multi_cta_itopk_size = 32;
     this->itopk_size                        = multi_cta_itopk_size;
     search_width                            = 1;
     RAFT_LOG_DEBUG("params.itopk_size: %lu", (uint64_t)params.itopk_size);
     RAFT_LOG_DEBUG("global_itopk_size: %lu", (uint64_t)global_itopk_size);
     num_cta_per_query =
-      max(params.search_width, raft::ceildiv(global_itopk_size, (size_t)multi_cta_itopk_size));
+      max(global_search_width, raft::ceildiv(global_itopk_size, (size_t)multi_cta_itopk_size));
     result_buffer_size = itopk_size + (search_width * graph_degree);
     typedef raft::Pow2<32> AlignBytes;
     unsigned result_buffer_size_32 = AlignBytes::roundUp(result_buffer_size);

--- a/cpp/src/neighbors/detail/cagra/search_plan.cuh
+++ b/cpp/src/neighbors/detail/cagra/search_plan.cuh
@@ -198,6 +198,11 @@ struct search_plan_impl : public search_plan_impl_base {
 
   void adjust_search_params()
   {
+    if (search_width == 0) {
+      search_width = raft::ceildiv(itopk_size, static_cast<size_t>(graph_degree));
+      RAFT_LOG_DEBUG("# search_width is auto-selected as %lu.", search_width);
+    }
+
     uint32_t _max_iterations = max_iterations;
     if (max_iterations == 0) {
       if (algo == search_algo::MULTI_CTA) {

--- a/cpp/src/neighbors/detail/cagra/search_plan.cuh
+++ b/cpp/src/neighbors/detail/cagra/search_plan.cuh
@@ -10,6 +10,7 @@
 #include <cuvs/neighbors/common.hpp>
 #include <neighbors/detail/cagra/compute_distance-ext.cuh>
 #include <raft/core/resource/cuda_stream.hpp>
+#include <raft/core/resource/device_properties.hpp>
 // #include "topk_for_cagra/topk.h"
 
 #include <raft/core/device_mdspan.hpp>
@@ -297,6 +298,17 @@ struct search_plan_impl : public search_plan_impl_base {
       }
       RAFT_EXPECTS(hash_bitlen <= 25, "hash_bitlen cannot be largen than 25 (32M)");
     } else {
+      constexpr size_t kib = 1024;
+      const auto shared_mem_per_sm =
+        raft::resource::get_device_properties(res).sharedMemPerMultiprocessor;
+      unsigned default_min_bitlen = 8;
+      if (shared_mem_per_sm >= 196 * kib) {
+        default_min_bitlen = 11;
+      } else if (shared_mem_per_sm >= 128 * kib) {
+        default_min_bitlen = 10;
+      } else if (shared_mem_per_sm >= 64 * kib) {
+        default_min_bitlen = 9;
+      }
       while (hashmap_mode == hash_mode::AUTO || hashmap_mode == hash_mode::SMALL) {
         //
         // The small-hash reduces hash table size by initializing the hash table
@@ -306,10 +318,9 @@ struct search_plan_impl : public search_plan_impl_base {
         // visited per iteration.
         //
         const auto max_visited_nodes = itopk_size + (search_width * graph_degree * 1);
-        unsigned min_bitlen          = 8;   // 256
+        unsigned min_bitlen = hashmap_min_bitlen == 0 ? default_min_bitlen : hashmap_min_bitlen;
         unsigned max_bitlen          = 13;  // 8K
-        if (min_bitlen < hashmap_min_bitlen) { min_bitlen = hashmap_min_bitlen; }
-        hash_bitlen = min_bitlen;
+        hash_bitlen                  = min_bitlen;
         while (max_visited_nodes > hashmap::get_size(hash_bitlen) * max_fill_rate) {
           hash_bitlen += 1;
         }

--- a/cpp/src/neighbors/detail/cagra/search_plan.cuh
+++ b/cpp/src/neighbors/detail/cagra/search_plan.cuh
@@ -206,9 +206,14 @@ struct search_plan_impl : public search_plan_impl_base {
     uint32_t _max_iterations = max_iterations;
     if (max_iterations == 0) {
       if (algo == search_algo::MULTI_CTA) {
-        constexpr uint32_t mc_itopk_size   = 32;
-        constexpr uint32_t mc_search_width = 1;
-        _max_iterations                    = mc_itopk_size / mc_search_width;
+        constexpr size_t mc_itopk_size  = 32;
+        constexpr size_t search_quality = 3;
+        const size_t minimum_depth      = 8 * (search_quality - 1);
+        const auto effective_itopk_size = raft::ceildiv(itopk_size, mc_itopk_size) * mc_itopk_size;
+        const auto num_ctas = max(search_width, raft::ceildiv(effective_itopk_size, mc_itopk_size));
+
+        _max_iterations = minimum_depth + raft::ceildiv(mc_itopk_size - minimum_depth, num_ctas);
+        _max_iterations += raft::ceildiv(static_cast<size_t>(topk), mc_itopk_size) - 1;
       } else {
         _max_iterations = itopk_size / search_width;
       }

--- a/cpp/src/neighbors/detail/cagra/search_plan.cuh
+++ b/cpp/src/neighbors/detail/cagra/search_plan.cuh
@@ -10,7 +10,6 @@
 #include <cuvs/neighbors/common.hpp>
 #include <neighbors/detail/cagra/compute_distance-ext.cuh>
 #include <raft/core/resource/cuda_stream.hpp>
-#include <raft/core/resource/device_properties.hpp>
 // #include "topk_for_cagra/topk.h"
 
 #include <raft/core/device_mdspan.hpp>
@@ -298,17 +297,6 @@ struct search_plan_impl : public search_plan_impl_base {
       }
       RAFT_EXPECTS(hash_bitlen <= 25, "hash_bitlen cannot be largen than 25 (32M)");
     } else {
-      constexpr size_t kib = 1024;
-      const auto shared_mem_per_sm =
-        raft::resource::get_device_properties(res).sharedMemPerMultiprocessor;
-      unsigned default_min_bitlen = 8;
-      if (shared_mem_per_sm >= 196 * kib) {
-        default_min_bitlen = 11;
-      } else if (shared_mem_per_sm >= 128 * kib) {
-        default_min_bitlen = 10;
-      } else if (shared_mem_per_sm >= 64 * kib) {
-        default_min_bitlen = 9;
-      }
       while (hashmap_mode == hash_mode::AUTO || hashmap_mode == hash_mode::SMALL) {
         //
         // The small-hash reduces hash table size by initializing the hash table
@@ -318,7 +306,9 @@ struct search_plan_impl : public search_plan_impl_base {
         // visited per iteration.
         //
         const auto max_visited_nodes = itopk_size + (search_width * graph_degree * 1);
-        unsigned min_bitlen = hashmap_min_bitlen == 0 ? default_min_bitlen : hashmap_min_bitlen;
+        // The SINGLE_CTA launcher may increase this automatic floor up to 13 if doing so does
+        // not reduce occupancy.
+        unsigned min_bitlen          = hashmap_min_bitlen == 0 ? 8 : hashmap_min_bitlen;
         unsigned max_bitlen          = 13;  // 8K
         hash_bitlen                  = min_bitlen;
         while (max_visited_nodes > hashmap::get_size(hash_bitlen) * max_fill_rate) {

--- a/cpp/src/neighbors/detail/cagra/search_single_cta.cuh
+++ b/cpp/src/neighbors/detail/cagra/search_single_cta.cuh
@@ -88,6 +88,8 @@ struct search
   using base_type::num_seeds;
 
   uint32_t num_itopk_candidates;
+  // JIT occupancy tuning is plan-wide; preserve its result across query chunks.
+  bool small_hash_occupancy_tuned = false;
 
   /** Number of elements in a hashmap covering @p n_queries queries across @p n_segments segments.
    */
@@ -320,6 +322,7 @@ struct search
                    small_hash_bitlen,
                    small_hash_reset_interval,
                    num_seeds,
+                   small_hash_occupancy_tuned,
                    sample_filter,
                    stream);
   }

--- a/cpp/src/neighbors/detail/cagra/search_single_cta_inst.cuh
+++ b/cpp/src/neighbors/detail/cagra/search_single_cta_inst.cuh
@@ -28,12 +28,13 @@ namespace cuvs::neighbors::cagra::detail::single_cta_search {
     uint32_t topk,                                                                 \
     uint32_t num_itopk_candidates,                                                 \
     uint32_t block_size,                                                           \
-    uint32_t smem_size,                                                            \
-    int64_t hash_bitlen,                                                           \
+    uint32_t& smem_size,                                                           \
+    int64_t& hash_bitlen,                                                          \
     uint32_t* hashmap_ptr,                                                         \
-    size_t small_hash_bitlen,                                                      \
-    size_t small_hash_reset_interval,                                              \
+    size_t& small_hash_bitlen,                                                     \
+    size_t& small_hash_reset_interval,                                             \
     uint32_t num_seeds,                                                            \
+    bool& small_hash_occupancy_tuned,                                              \
     SampleFilterT sample_filter,                                                   \
     cudaStream_t stream);
 

--- a/cpp/src/neighbors/detail/cagra/search_single_cta_kernel.cuh
+++ b/cpp/src/neighbors/detail/cagra/search_single_cta_kernel.cuh
@@ -30,12 +30,13 @@ void select_and_run(
   uint32_t topk,
   uint32_t num_itopk_candidates,
   uint32_t block_size,  //
-  uint32_t smem_size,
-  int64_t hash_bitlen,
+  uint32_t& smem_size,
+  int64_t& hash_bitlen,
   IndexT* hashmap_ptr,
-  size_t small_hash_bitlen,
-  size_t small_hash_reset_interval,
+  size_t& small_hash_bitlen,
+  size_t& small_hash_reset_interval,
   uint32_t num_seeds,
+  bool& small_hash_occupancy_tuned,
   SampleFilterT sample_filter,
   cudaStream_t stream);
 

--- a/cpp/src/neighbors/detail/cagra/search_single_cta_kernel_launcher_jit.cuh
+++ b/cpp/src/neighbors/detail/cagra/search_single_cta_kernel_launcher_jit.cuh
@@ -798,12 +798,13 @@ void select_and_run(
   uint32_t topk,
   uint32_t num_itopk_candidates,
   uint32_t block_size,  //
-  uint32_t smem_size,
-  int64_t hash_bitlen,
+  uint32_t& smem_size,
+  int64_t& hash_bitlen,
   IndexT* hashmap_ptr,
-  size_t small_hash_bitlen,
-  size_t small_hash_reset_interval,
+  size_t& small_hash_bitlen,
+  size_t& small_hash_reset_interval,
   uint32_t num_seeds,
+  bool& small_hash_occupancy_tuned,
   SampleFilterT sample_filter,
   cudaStream_t stream)
 {
@@ -868,6 +869,42 @@ void select_and_run(
         false /* persistent */,
         make_cagra_sample_filter_udf_fragment<SourceIndexT>(sample_filter));
     if (!launcher) { RAFT_FAIL("Failed to get JIT launcher for CAGRA search kernel"); }
+
+    if (!small_hash_occupancy_tuned && ps.hashmap_min_bitlen == 0 && small_hash_bitlen != 0) {
+      // Grow the per-CTA small hash only while the concrete JIT kernel retains its occupancy.
+      auto kernel = launcher->get_kernel();
+      RAFT_CUDA_TRY(
+        cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size));
+      int blocks_per_sm = 0;
+      RAFT_CUDA_TRY(cudaOccupancyMaxActiveBlocksPerMultiprocessor(
+        &blocks_per_sm, kernel, block_size, smem_size));
+
+      constexpr size_t max_small_hash_bitlen = 13;
+      for (size_t candidate_bitlen = small_hash_bitlen + 1;
+           candidate_bitlen <= max_small_hash_bitlen;
+           ++candidate_bitlen) {
+        const auto candidate_smem_size =
+          smem_size + sizeof(IndexT) * (hashmap::get_size(candidate_bitlen) -
+                                        hashmap::get_size(small_hash_bitlen));
+        RAFT_CUDA_TRY(cudaFuncSetAttribute(
+          kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, candidate_smem_size));
+        int candidate_blocks_per_sm = 0;
+        RAFT_CUDA_TRY(cudaOccupancyMaxActiveBlocksPerMultiprocessor(
+          &candidate_blocks_per_sm, kernel, block_size, candidate_smem_size));
+        if (candidate_blocks_per_sm < blocks_per_sm) { break; }
+
+        small_hash_bitlen         = candidate_bitlen;
+        hash_bitlen               = candidate_bitlen;
+        smem_size                 = candidate_smem_size;
+        blocks_per_sm             = candidate_blocks_per_sm;
+      }
+      // A larger hash allows less frequent resets while preserving the fill-rate limit.
+      const auto usable_hash_slots =
+        static_cast<size_t>(hashmap::get_size(small_hash_bitlen) * ps.hashmap_max_fill_rate);
+      small_hash_reset_interval =
+        std::max<size_t>(1, (usable_hash_slots - ps.itopk_size) / num_itopk_candidates - 1);
+      small_hash_occupancy_tuned = true;
+    }
 
     // Get the device descriptor pointer - dev_ptr() initializes it if needed
     const auto* dev_desc = dataset_desc.dev_ptr(stream);

--- a/fern/pages/cuvs_bench/param_tuning.md
+++ b/fern/pages/cuvs_bench/param_tuning.md
@@ -89,7 +89,7 @@ CAGRA uses a graph-based index, which creates an intermediate, approximate kNN g
 | `use_disk` | `build` | N | Boolean | `false` | Whether to use disk-based storage for ACE build. When true, forces ACE to use disk-based storage even if the graph fits in host and GPU memory. When false, ACE will use in-memory storage if the graph fits in host and GPU memory and disk-based storage otherwise. |
 | `query_memory_type` | `search` | N | [`device`, `host`, `mmap`] | `device` | Where should the queries reside? |
 | `itopk` | `search` | N | Positive integer >0 | 64 | Number of intermediate search results retained during the search. Higher values improve search accuracy at the cost of speed |
-| `search_width` | `search` | N | Positive integer >0 | 1 | Number of graph nodes to select as the starting point for the search in each iteration. |
+| `search_width` | `search` | N | Non-negative integer | 1 | Number of graph nodes to select as the starting point for the search in each iteration. A value of 0 selects `ceil(itopk_size / graph_degree)`. |
 | `max_iterations` | `search` | N | Positive integer >=0 | 0 | Upper limit of search iterations. Auto select when 0 |
 | `algo` | `search` | N | [`auto`, `single_cta`, `multi_cta`, `multi_kernel`] | `auto` | Algorithm to use for search. It's usually best to leave this to `auto`. |
 | `persistent` | `search` | N | Boolean | `false` | Enables the persistent CAGRA search kernel for high-throughput search with many concurrent client threads. Persistent search currently requires `single_cta`; `auto` selects it when persistent mode is enabled. |


### PR DESCRIPTION
<!--

Thank you for contributing to cuvs :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present) and replace
   it with `[REVIEW]`. If assistance is required to complete the functionality,
   for example when the C/C++ code of a feature is complete but Python bindings
   are still required, then add the label `[HELP-REQ]` so that others can triage
   and assist. The additional changes then can be implemented on top of the
   same PR. If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on master/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against master they should be resolved by merging master
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->

- Enable auto search_width selection. 

current default at 1 can be too weak for large itopk, e.g. itopk=512, width=1, graph_degree=64, and does not introduce enough diversity by each expansion. Support search_width=0 now, which select width to be `ceildiv(itopk,graph_degree)`

- Adjust hashmap_min_bitlen based on shared memory size. 

The current default (min_bitlen=8) can be too conservative, and often limits the hash reset interval to just 1 (reset every iteration). For later GPU architectures SMEM is usually larger and we can afford a larger hashmap size. I did experiments on a B300 with 228KB SMEM and min_bitlen=11 is consistently best performing for itopk <=256 (for itopk=512 12 bits wins).
<img width="1870" height="1157" alt="compare_bitlen" src="https://github.com/user-attachments/assets/ee804222-dcbb-46fa-8a4d-d0f1bf5fab43" />

- Improve auto max_iterations for multi-CTA algo. Previous fixed `base_iteration=32` is too conservative and the QPS-recall curve is way below the actual pareto curve. Added a `search_quality` parameter to adjust the search budget. This parameter is fixed to 3 for the moment.

<img width="1050" height="720" alt="compare_quality_k10_nq1,pareto" src="https://github.com/user-attachments/assets/1cf946f1-9790-4cdd-a54b-fd3dc31c5b7a" />


- ~Fix slow recall calculation issue at low batch.~ Please review and merge #2513 first.