### PR TITLE
Fix init of device_scalars

### DIFF
--- a/cpp/src/cluster/detail/kmeans_balanced.cuh
+++ b/cpp/src/cluster/detail/kmeans_balanced.cuh
@@ -681,10 +681,12 @@ auto adjust_centers(const raft::resources& handle,
   rmm::device_uvector<IdxT> donor_clusters(n_pairs, stream, device_memory);
   constexpr uint32_t kBlockDimY = 4;
   const dim3 block_dim(raft::WarpSize, kBlockDimY, 1);
-  rmm::device_scalar<IdxT> update_count(0, stream, device_memory);
+  rmm::device_scalar<IdxT> update_count(stream, device_memory);
+  update_count.set_value_to_zero_async(stream);
 
   if (donor_selection == cuvs::cluster::kmeans::balanced_donor_selection::Random) {
-    rmm::device_scalar<IdxT> search_count(0, stream, device_memory);
+    rmm::device_scalar<IdxT> search_count(stream, device_memory);
+    search_count.set_value_to_zero_async(stream);
     const dim3 grid_dim(raft::ceildiv(n_clusters, static_cast<IdxT>(kBlockDimY)), 1, 1);
     adjust_centers_random_donor_kernel<kBlockDimY>
       <<<grid_dim, block_dim, 0, stream>>>(centers,

--- a/cpp/src/distance/detail/sparse/coo_spmv_strategies/coo_mask_row_iterators.cuh
+++ b/cpp/src/distance/detail/sparse/coo_spmv_strategies/coo_mask_row_iterators.cuh
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -118,8 +118,7 @@ class chunked_mask_row_it : public mask_row_it<value_idx> {
   {
     auto policy = rmm::exec_policy(stream);
 
-    constexpr value_idx first_element = 0;
-    n_chunks_per_row.set_element_async(0, first_element, stream);
+    n_chunks_per_row.set_element_to_zero_async(0, stream);
     n_chunks_per_row_functor chunk_functor(indptr, row_chunk_size);
     thrust::transform(
       policy, mask_row_idx, mask_row_idx + n_rows, n_chunks_per_row.begin() + 1, chunk_functor);


### PR DESCRIPTION
Zeroed with a device memset. The `device_scalar(value, stream)` ctor would copy from a host temporary that dies before the copy is guaranteed to have read it. So the value ends up being something random.

xref https://github.com/rapidsai/rmm/issues/2526 https://github.com/NVIDIA/cuml/issues/8510