### PR TITLE
Fix `cuvs` build due to `rmm` and `cuCollections` api changes

### DIFF
--- a/cpp/src/cluster/detail/kmeans_balanced.cuh
+++ b/cpp/src/cluster/detail/kmeans_balanced.cuh
@@ -681,10 +681,12 @@ auto adjust_centers(const raft::resources& handle,
   rmm::device_uvector<IdxT> donor_clusters(n_pairs, stream, device_memory);
   constexpr uint32_t kBlockDimY = 4;
   const dim3 block_dim(raft::WarpSize, kBlockDimY, 1);
-  rmm::device_scalar<IdxT> update_count(0, stream, device_memory);
+  rmm::device_scalar<IdxT> update_count(stream, device_memory);
+  update_count.set_value_to_zero_async(stream);
 
   if (donor_selection == cuvs::cluster::kmeans::balanced_donor_selection::Random) {
-    rmm::device_scalar<IdxT> search_count(0, stream, device_memory);
+    rmm::device_scalar<IdxT> search_count(stream, device_memory);
+    search_count.set_value_to_zero_async(stream);
     const dim3 grid_dim(raft::ceildiv(n_clusters, static_cast<IdxT>(kBlockDimY)), 1, 1);
     adjust_centers_random_donor_kernel<kBlockDimY>
       <<<grid_dim, block_dim, 0, stream>>>(centers,

--- a/cpp/src/core/bloom_filter.cu
+++ b/cpp/src/core/bloom_filter.cu
@@ -7,6 +7,7 @@
 #include <cuvs/core/bloom_filter.hpp>
 
 #include <cuco/bloom_filter.cuh>
+#include <cuco/bloom_filter_policy.cuh>
 
 #include <raft/core/error.hpp>
 #include <raft/core/resource/cuda_stream.hpp>
@@ -20,7 +21,7 @@ namespace cuvs::core {
 
 namespace {
 
-using default_filter_policy = cuco::default_filter_policy<bloom_filter::key_type>;
+using default_filter_policy = cuco::bloom_filter_policy<bloom_filter::key_type>;
 
 constexpr auto kPatternBits   = default_filter_policy::pattern_bits;
 constexpr auto kWordsPerBlock = default_filter_policy::words_per_block;

--- a/cpp/src/distance/detail/sparse/coo_spmv_strategies/coo_mask_row_iterators.cuh
+++ b/cpp/src/distance/detail/sparse/coo_spmv_strategies/coo_mask_row_iterators.cuh
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -118,8 +118,7 @@ class chunked_mask_row_it : public mask_row_it<value_idx> {
   {
     auto policy = rmm::exec_policy(stream);
 
-    constexpr value_idx first_element = 0;
-    n_chunks_per_row.set_element_async(0, first_element, stream);
+    n_chunks_per_row.set_element_to_zero_async(0, stream);
     n_chunks_per_row_functor chunk_functor(indptr, row_chunk_size);
     thrust::transform(
       policy, mask_row_idx, mask_row_idx + n_rows, n_chunks_per_row.begin() + 1, chunk_functor);

--- a/cpp/tests/neighbors/brute_force_prefiltered.cu
+++ b/cpp/tests/neighbors/brute_force_prefiltered.cu
@@ -198,10 +198,11 @@ class PrefilteredBruteForceOnBitmapTest
 
     index_t nnz_h = 0;
     {
-      auto src    = out_src.data();
-      auto dst    = out_dst.data();
-      auto bitmap = filter_d.data();
-      rmm::device_scalar<index_t> nnz(0, stream);
+      auto src     = out_src.data();
+      auto dst     = out_dst.data();
+      auto bitmap  = filter_d.data();
+      index_t zero = 0;
+      rmm::device_scalar<index_t> nnz(zero, stream);
       auto nnz_view = raft::make_device_scalar_view<index_t>(nnz.data());
       auto filter_view =
         raft::make_device_vector_view<const uint32_t, index_t>(filter_d.data(), filter_d.size());
@@ -616,10 +617,11 @@ class PrefilteredBruteForceOnBitsetTest
 
     index_t nnz_h = 0;
     {
-      auto src    = out_src.data();
-      auto dst    = out_dst.data();
-      auto bitset = filter_d.data();
-      rmm::device_scalar<index_t> nnz(0, stream);
+      auto src     = out_src.data();
+      auto dst     = out_dst.data();
+      auto bitset  = filter_d.data();
+      index_t zero = 0;
+      rmm::device_scalar<index_t> nnz(zero, stream);
       auto nnz_view = raft::make_device_scalar_view<index_t>(nnz.data());
       auto filter_view =
         raft::make_device_vector_view<const uint32_t, index_t>(filter_d.data(), filter_d.size());


### PR DESCRIPTION
`rapids-cmake` just bumped the commit used for `cuCollections` in builds, leading to `cuvs` build failures.

Here we fix usage of `cuco::default_filter_policy` that were changed in https://github.com/NVIDIA/cuCollections/pull/827.

Also fixes some fallout from https://github.com/rapidsai/rmm/pull/2527, merging in #2503 (as well as a few small fixups).

Closes #2503.