### PR TITLE
test: isolate library wheel smoke test, add missing 'cuda-pathfinder' dependency for 'libcuvs'

### DIFF
--- a/ci/test_wheel_cuvs.sh
+++ b/ci/test_wheel_cuvs.sh
@@ -22,7 +22,7 @@ rapids-pip-retry install \
     -v \
     --prefer-binary \
     --constraint "${PIP_CONSTRAINT}" \
-    "${LIBCUVS_WHEELHOUSE}"/libcugraph*.whl
+    "${LIBCUVS_WHEELHOUSE}"/libcuvs*.whl
 python -c "import libcuvs; assert (libraries := libcuvs.load_library()) and all(libraries)"
 deactivate
 

--- a/ci/test_wheel_cuvs.sh
+++ b/ci/test_wheel_cuvs.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 set -euo pipefail
@@ -14,6 +14,17 @@ CUVS_WHEELHOUSE=$(rapids-download-from-github "$(rapids-artifact-name wheel_pyth
 
 # generate constraints (possibly pinning to oldest support versions of dependencies)
 rapids-generate-pip-constraints test_python "${PIP_CONSTRAINT}"
+
+python -m venv libcuvs-env
+. libcuvs-env/bin/activate
+
+rapids-pip-retry install \
+    -v \
+    --prefer-binary \
+    --constraint "${PIP_CONSTRAINT}" \
+    "${LIBCUVS_WHEELHOUSE}"/libcugraph*.whl
+python -c "import libcuvs; assert (libraries := libcuvs.load_library()) and all(libraries)"
+deactivate
 
 # notes:
 #

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -152,6 +152,7 @@ files:
       - depends_on_libraft
       - depends_on_librmm
       - depends_on_nccl
+      - run_py_libcuvs
   py_build_cuvs:
     output: pyproject
     pyproject_dir: python/cuvs
@@ -560,6 +561,11 @@ dependencies:
       - output_types: [conda, requirements, pyproject]
         packages:
           - &numpy numpy>=2.0,<3.0
+  run_py_libcuvs:
+    common:
+      - output_types: [requirements, pyproject]
+        packages:
+          - cuda-pathfinder
   test_python_common:
     common:
       - output_types: [conda, requirements, pyproject]

--- a/python/libcuvs/pyproject.toml
+++ b/python/libcuvs/pyproject.toml
@@ -19,6 +19,7 @@ authors = [
 license = "Apache-2.0"
 requires-python = ">=3.11"
 dependencies = [
+    "cuda-pathfinder",
     "cuda-toolkit[cublas,curand,cusolver,cusparse,nvrtc]==13.*",
     "libraft==26.10.*,>=0.0.0a0",
     "librmm==26.10.*,>=0.0.0a0",


### PR DESCRIPTION
## Description

Adds a CI check installing the `libcuvs` wheel in a clean virtual environment and calling its `load_library()` entry point before installing the high-level wheel or test extras. This exposes missing library-wheel runtime dependencies that the full test environment can otherwise mask.

Through this testing, found that `libcuvs` was missing a dependency on `cuda-pathfinder` for this:

https://github.com/NVIDIA/cuvs/blob/9c9d359aa51e4d279a27a94b0d1f14cacc2e34ee/python/libcuvs/libcuvs/load.py#L42

xref: https://github.com/rapidsai/build-planning/issues/307
