### PR TITLE
Use JIT-LTO kernel handles through an API the toolkit actually provides

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -1532,6 +1532,19 @@ if(NOT BUILD_CPU_ONLY)
                                  ${CUVS_CUSPARSE_DEPENDENCY} ${CUVS_CURAND_DEPENDENCY}
   )
 
+  # Before CUDA 12.8 the runtime rejects a cudaKernel_t where a kernel entry point is expected, and
+  # cudaKernelSetAttributeForDevice does not exist at all, so the JIT-LTO kernel handles are queried
+  # and configured through the equivalent driver-API entry points instead (see
+  # src/util/jit_kernel_compat.hpp). That needs the driver stub at link time.
+  set(CUVS_CUDA_DRIVER_DEPENDENCY "")
+  if(CUDAToolkit_VERSION VERSION_LESS 12.8)
+    set(CUVS_CUDA_DRIVER_DEPENDENCY CUDA::cuda_driver)
+    message(
+      STATUS
+        "cuVS: CUDA ${CUDAToolkit_VERSION} does not accept kernel handles in the runtime API; using the driver API for JIT-LTO kernel attributes"
+    )
+  endif()
+
   if(NOT cuvs_compile_mode STREQUAL "static_only")
     add_library(cuvs SHARED $<TARGET_OBJECTS:cuvs_objs>)
     add_library(cuvs::cuvs ALIAS cuvs)
@@ -1571,6 +1584,7 @@ if(NOT BUILD_CPU_ONLY)
              $<$<BOOL:${CUVS_NVTX}>:CUDA::nvtx3>
       PRIVATE $<TARGET_NAME_IF_EXISTS:OpenMP::OpenMP_CXX> $<COMPILE_ONLY:nvidia::cutlass::cutlass>
               $<COMPILE_ONLY:cuco::cuco> CUDA::nvJitLink CUDA::nvrtc rtcx::rtcx
+              ${CUVS_CUDA_DRIVER_DEPENDENCY}
     )
 
     # ensure CUDA symbols aren't relocated to the middle of the debug build binaries
@@ -1629,6 +1643,7 @@ SECTIONS
               CUDA::nvJitLink
               CUDA::nvrtc
               rtcx::rtcx
+              ${CUVS_CUDA_DRIVER_DEPENDENCY}
               $<$<BOOL:${CUVS_NVTX}>:CUDA::nvtx3>
               $<COMPILE_ONLY:nvidia::cutlass::cutlass>
               $<COMPILE_ONLY:cuco::cuco>

--- a/cpp/src/distance/detail/pairwise_distance_base.cuh
+++ b/cpp/src/distance/detail/pairwise_distance_base.cuh
@@ -6,11 +6,13 @@
 #ifdef CUVS_DISTANCE_PAIRWISE_USE_JIT
 #include "pairwise_matrix/jit_lto_kernels/device_functions.cuh"
 #endif
+#include <util/jit_kernel_compat.hpp>  // kernel_max_active_blocks_per_multiprocessor
 #include <raft/linalg/contractions.cuh>       // raft::linalg::Contractions_NT
 #include <raft/util/cuda_dev_essentials.cuh>  // ceildiv
 #include <raft/util/cuda_rt_essentials.hpp>   // RAFT_CUDA_TRY
 
-#include <cstddef>  // size_t
+#include <cstddef>      // size_t
+#include <type_traits>  // std::is_same_v
 
 namespace cuvs {
 namespace distance {
@@ -310,8 +312,14 @@ dim3 launchConfigGenerator(IdxT m, IdxT n, std::size_t sMemSize, T func)
   int numBlocksPerSm = 0;
   dim3 grid;
 
-  RAFT_CUDA_TRY(
-    cudaOccupancyMaxActiveBlocksPerMultiprocessor(&numBlocksPerSm, func, P::Nthreads, sMemSize));
+  if constexpr (std::is_same_v<T, cudaKernel_t>) {
+    // A JIT-LTO kernel handle: the runtime occupancy API only accepts one on CUDA 12.8+.
+    RAFT_CUDA_TRY(cuvs::util::kernel_max_active_blocks_per_multiprocessor(
+      &numBlocksPerSm, func, P::Nthreads, sMemSize));
+  } else {
+    RAFT_CUDA_TRY(
+      cudaOccupancyMaxActiveBlocksPerMultiprocessor(&numBlocksPerSm, func, P::Nthreads, sMemSize));
+  }
   std::size_t minGridSize = numSMs * numBlocksPerSm;
   std::size_t yChunks     = raft::ceildiv<int>(m, P::Mblk);
   std::size_t xChunks     = raft::ceildiv<int>(n, P::Nblk);

--- a/cpp/src/neighbors/detail/cagra/search_single_cta_kernel_launcher_jit.cuh
+++ b/cpp/src/neighbors/detail/cagra/search_single_cta_kernel_launcher_jit.cuh
@@ -20,6 +20,7 @@
 #include "search_single_cta_kernel_launcher_common.cuh"
 #include "shared_launcher_jit.hpp"  // For shared JIT helper functions
 
+#include <util/jit_kernel_compat.hpp>
 #include <raft/util/integer_utils.hpp>
 #include <raft/util/pow2_utils.cuh>
 
@@ -765,7 +766,9 @@ struct alignas(kCacheLineBytes) persistent_runner_jit_t : public persistent_runn
   {
     int ctas_per_sm            = 1;
     cudaKernel_t kernel_handle = launcher->get_kernel();
-    RAFT_CUDA_TRY(cudaOccupancyMaxActiveBlocksPerMultiprocessor(
+    // Not `cudaOccupancyMaxActiveBlocksPerMultiprocessor`: it only accepts a `cudaKernel_t` on
+    // CUDA 12.8+.
+    RAFT_CUDA_TRY(cuvs::util::kernel_max_active_blocks_per_multiprocessor(
       &ctas_per_sm, kernel_handle, block_size, smem_size));
     int num_sm    = raft::getMultiProcessorCount();
     auto n_blocks = static_cast<uint32_t>(persistent_device_usage * (ctas_per_sm * num_sm));

--- a/cpp/src/neighbors/detail/smem_utils.cuh
+++ b/cpp/src/neighbors/detail/smem_utils.cuh
@@ -9,6 +9,7 @@
 #include <cuda_runtime.h>
 #include <mutex>
 #include <raft/core/error.hpp>
+#include <util/jit_kernel_compat.hpp>
 
 namespace cuvs::neighbors::detail {
 
@@ -81,7 +82,8 @@ void safely_launch_kernel_with_smem_size(std::uint32_t smem_size,
       need_update   = true;
     }
     if (need_update) {
-      auto launch_status = cudaFuncSetAttribute(
+      // Not `cudaFuncSetAttribute`: it only accepts a `cudaKernel_t` on CUDA 12.8+.
+      auto launch_status = cuvs::util::kernel_set_attribute(
         cuda_kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, cur_smem_size);
       RAFT_EXPECTS(launch_status == cudaSuccess,
                    "Failed to set max dynamic shared memory size to %u bytes",

--- a/cpp/src/neighbors/ivf_flat/ivf_flat_interleaved_scan_jit.cuh
+++ b/cpp/src/neighbors/ivf_flat/ivf_flat_interleaved_scan_jit.cuh
@@ -11,6 +11,7 @@
 #include <cstdint>
 #include <cuvs/detail/jit_lto/common_fragments.hpp>
 #include <cuvs/detail/jit_lto/ivf_flat/interleaved_scan_fragments.hpp>
+#include <util/jit_kernel_compat.hpp>
 #include <cuvs/neighbors/common.hpp>
 #include <cuvs/neighbors/ivf_flat.hpp>
 #include <optional>
@@ -117,7 +118,9 @@ inline uint32_t configure_launch_x(uint32_t numQueries,
   int num_sms;
   RAFT_CUDA_TRY(cudaDeviceGetAttribute(&num_sms, cudaDevAttrMultiProcessorCount, dev_id));
   int num_blocks_per_sm = 0;
-  RAFT_CUDA_TRY(cudaOccupancyMaxActiveBlocksPerMultiprocessor(
+  // Not `cudaOccupancyMaxActiveBlocksPerMultiprocessor`: it only accepts a `cudaKernel_t` on
+  // CUDA 12.8+.
+  RAFT_CUDA_TRY(cuvs::util::kernel_max_active_blocks_per_multiprocessor(
     &num_blocks_per_sm, func, kThreadsPerBlock, sMemSize));
 
   size_t min_grid_size = num_sms * num_blocks_per_sm;

--- a/cpp/src/neighbors/ivf_pq/ivf_pq_compute_similarity_impl.cuh
+++ b/cpp/src/neighbors/ivf_pq/ivf_pq_compute_similarity_impl.cuh
@@ -14,6 +14,7 @@
 #include "ivf_pq_fp_8bit.cuh"
 #include <cuvs/distance/distance.hpp>  // cuvs::distance::DistanceType
 #include <cuvs/neighbors/common.hpp>
+#include <util/jit_kernel_compat.hpp>
 #include <cuvs/neighbors/ivf_pq.hpp>               // codebook_gen
 #include <raft/matrix/detail/select_warpsort.cuh>  // matrix::detail::select::warpsort::warp_sort_distributed
 #include <raft/util/cuda_rt_essentials.hpp>  // RAFT_CUDA_TRY
@@ -255,8 +256,10 @@ struct occupancy_t {
                      cudaKernel_t kernel,
                      const cudaDeviceProp& dev_props)
   {
-    RAFT_CUDA_TRY(
-      cudaOccupancyMaxActiveBlocksPerMultiprocessor(&blocks_per_sm, kernel, n_threads, smem));
+    // Not `cudaOccupancyMaxActiveBlocksPerMultiprocessor`: it only accepts a `cudaKernel_t` on
+    // CUDA 12.8+.
+    RAFT_CUDA_TRY(cuvs::util::kernel_max_active_blocks_per_multiprocessor(
+      &blocks_per_sm, kernel, n_threads, smem));
     occupancy = double(blocks_per_sm * n_threads) / double(dev_props.maxThreadsPerMultiProcessor);
     shmem_use = double(shmem_unit::roundUp(smem) * blocks_per_sm) /
                 double(dev_props.sharedMemPerMultiprocessor);
@@ -483,12 +486,12 @@ auto compute_similarity_select(const cudaDeviceProp& dev_props,
     // usage and occupancy.
     const int max_carveout =
       estimate_carveout(preferred_shmem_carveout, smem_size_f(raft::WarpSize), dev_props);
-    RAFT_CUDA_TRY(
-      cudaFuncSetAttribute(kernel, cudaFuncAttributePreferredSharedMemoryCarveout, max_carveout));
+    RAFT_CUDA_TRY(cuvs::util::kernel_set_attribute(
+      kernel, cudaFuncAttributePreferredSharedMemoryCarveout, max_carveout));
 
     // Get the theoretical maximum possible number of threads per block
     cudaFuncAttributes kernel_attrs;
-    RAFT_CUDA_TRY(cudaFuncGetAttributes(&kernel_attrs, kernel));
+    RAFT_CUDA_TRY(cuvs::util::kernel_get_attributes(&kernel_attrs, kernel));
     uint32_t n_threads =
       raft::round_down_safe<uint32_t>(kernel_attrs.maxThreadsPerBlock, n_threads_gty);
 
@@ -496,13 +499,14 @@ auto compute_similarity_select(const cudaDeviceProp& dev_props,
     size_t smem_size = smem_size_f(n_threads);
 
     // Make sure the kernel can get enough shmem.
-    cudaError_t cuda_status =
-      cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size);
+    cudaError_t cuda_status = cuvs::util::kernel_set_attribute(
+      kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, static_cast<int>(smem_size));
     if (cuda_status != cudaSuccess) {
-      RAFT_EXPECTS(
-        cuda_status == cudaGetLastError(),
-        "Tried to reset the expected cuda error code, but it didn't match the expectation");
-      // Failed to request enough shmem for the kernel. Skip the candidate.
+      // Failed to request enough shmem for the kernel. Skip the candidate, after clearing the
+      // error so that it is not mistaken for a failure of the next CUDA call. (The driver-API
+      // path of kernel_set_attribute does not set the runtime's sticky error at all, so the
+      // status has to be inspected directly rather than through cudaGetLastError.)
+      cudaGetLastError();
       continue;
     }
 
@@ -578,8 +582,8 @@ auto compute_similarity_select(const cudaDeviceProp& dev_props,
         // a rather conservative bar; most likely, the kernel gets more shared memory than this,
         // and the occupancy doesn't get hurt.
         auto carveout = std::min<int>(max_carveout, std::ceil(100.0 * cur.shmem_use));
-        RAFT_CUDA_TRY(
-          cudaFuncSetAttribute(kernel, cudaFuncAttributePreferredSharedMemoryCarveout, carveout));
+        RAFT_CUDA_TRY(cuvs::util::kernel_set_attribute(
+          kernel, cudaFuncAttributePreferredSharedMemoryCarveout, carveout));
         if (cur.occupancy >= kTargetOccupancy) { break; }
       } else if (selected_perf.occupancy > 0.0) {
         // If we found a reasonable candidate on a previous iteration, and this one is not better,

--- a/cpp/src/neighbors/ivf_sq/ivf_sq_search.cuh
+++ b/cpp/src/neighbors/ivf_sq/ivf_sq_search.cuh
@@ -13,6 +13,7 @@
 #include "detail/jit_lto_kernels/scan_planner.hpp"
 #include <cuvs/detail/jit_lto/common_fragments.hpp>
 #include <cuvs/detail/jit_lto/ivf_sq/scan_fragments.hpp>
+#include <util/jit_kernel_compat.hpp>
 #include <cuvs/neighbors/common.hpp>
 #include <cuvs/neighbors/ivf_sq.hpp>
 
@@ -110,7 +111,9 @@ inline uint32_t configure_grid_dim_x(
   int num_sms;
   RAFT_CUDA_TRY(cudaDeviceGetAttribute(&num_sms, cudaDevAttrMultiProcessorCount, dev_id));
   int num_blocks_per_sm = 0;
-  RAFT_CUDA_TRY(cudaOccupancyMaxActiveBlocksPerMultiprocessor(
+  // Not `cudaOccupancyMaxActiveBlocksPerMultiprocessor`: it only accepts a `cudaKernel_t` on
+  // CUDA 12.8+.
+  RAFT_CUDA_TRY(cuvs::util::kernel_max_active_blocks_per_multiprocessor(
     &num_blocks_per_sm, kernel, block_size, smem_size));
 
   size_t min_grid_size = size_t(num_sms) * num_blocks_per_sm;
@@ -205,10 +208,11 @@ void launch_kernel(const index<CodeT>& idx,
   {
     int dev_id;
     RAFT_CUDA_TRY(cudaGetDevice(&dev_id));
-    RAFT_CUDA_TRY(cudaKernelSetAttributeForDevice(kernel_launcher->get_kernel(),
-                                                  cudaFuncAttributeMaxDynamicSharedMemorySize,
-                                                  static_cast<int>(smem),
-                                                  dev_id));
+    // Not `cudaKernelSetAttributeForDevice`: that API does not exist before CUDA 12.8.
+    RAFT_CUDA_TRY(cuvs::util::kernel_set_attribute(kernel_launcher->get_kernel(),
+                                                   cudaFuncAttributeMaxDynamicSharedMemorySize,
+                                                   static_cast<int>(smem),
+                                                   dev_id));
   }
 
   constexpr uint32_t kMaxGridY = 65535;

--- a/cpp/src/util/jit_kernel_compat.hpp
+++ b/cpp/src/util/jit_kernel_compat.hpp
@@ -1,0 +1,203 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file jit_kernel_compat.hpp
+ * @brief Toolkit-version shim for the CUDA APIs cuVS calls on JIT-LTO kernel handles.
+ *
+ * The JIT-LTO path hands out `cudaKernel_t` handles for kernels that were linked at run time and
+ * loaded from a library image rather than compiled into the binary. cuVS then queries and sets
+ * attributes on those handles.
+ *
+ * The CUDA *runtime* only accepts a `cudaKernel_t` where a `const void* func` is expected from
+ * CUDA 12.8 onwards -- "If the specified function does not exist, then it is assumed to be a
+ * cudaKernel_t and used as is", a sentence that appears in the 12.8 documentation of
+ * `cudaFuncGetAttributes`, `cudaFuncSetAttribute` and
+ * `cudaOccupancyMaxActiveBlocksPerMultiprocessor`, and in no earlier version.
+ * `cudaKernelSetAttributeForDevice` does not exist at all before 12.8 -- it is absent from both the
+ * headers and `libcudart.so`. On an older toolkit the calls therefore fail with
+ * `cudaErrorInvalidDeviceFunction`, or do not compile.
+ *
+ * The *driver* API has always taken the equivalent `CUkernel` / `CUfunction`, and
+ * `cudaKernel_t` is `struct CUkern_st*`, i.e. exactly `CUkernel`, so the handles carry over
+ * unchanged. This header forwards to the runtime API when it is available and to the driver API
+ * otherwise; on 12.8+ every wrapper compiles down to the original runtime call and no driver
+ * dependency is added.
+ */
+
+#pragma once
+
+#include <cuda_runtime.h>
+
+#include <cstddef>
+
+/** 1 when the CUDA runtime accepts `cudaKernel_t` in the function-attribute APIs, 0 when not. */
+#if defined(CUDART_VERSION) && (CUDART_VERSION >= 12080)
+#define CUVS_RUNTIME_ACCEPTS_KERNEL_HANDLES 1
+#else
+#define CUVS_RUNTIME_ACCEPTS_KERNEL_HANDLES 0
+#endif
+
+#if !CUVS_RUNTIME_ACCEPTS_KERNEL_HANDLES
+#include <cuda.h>
+#endif
+
+namespace cuvs::util {
+
+namespace detail {
+
+#if !CUVS_RUNTIME_ACCEPTS_KERNEL_HANDLES
+
+/** Translate a driver-API status into the closest runtime-API status. */
+inline cudaError_t from_driver(CUresult status)
+{
+  switch (status) {
+    case CUDA_SUCCESS: return cudaSuccess;
+    case CUDA_ERROR_OUT_OF_MEMORY: return cudaErrorMemoryAllocation;
+    case CUDA_ERROR_NOT_INITIALIZED: return cudaErrorInitializationError;
+    case CUDA_ERROR_DEINITIALIZED: return cudaErrorCudartUnloading;
+    case CUDA_ERROR_NO_DEVICE: return cudaErrorNoDevice;
+    case CUDA_ERROR_INVALID_DEVICE: return cudaErrorInvalidDevice;
+    case CUDA_ERROR_INVALID_VALUE: return cudaErrorInvalidValue;
+    case CUDA_ERROR_INVALID_HANDLE: return cudaErrorInvalidResourceHandle;
+    case CUDA_ERROR_NOT_FOUND: return cudaErrorSymbolNotFound;
+    case CUDA_ERROR_INVALID_IMAGE: return cudaErrorInvalidKernelImage;
+    case CUDA_ERROR_NO_BINARY_FOR_GPU: return cudaErrorNoKernelImageForDevice;
+    case CUDA_ERROR_LAUNCH_OUT_OF_RESOURCES: return cudaErrorLaunchOutOfResources;
+    case CUDA_ERROR_INVALID_CONTEXT: return cudaErrorDeviceUninitialized;
+    default: return cudaErrorUnknown;
+  }
+}
+
+/**
+ * Make sure the runtime's primary context exists and is current.
+ *
+ * Driver-API calls such as `cuKernelGetFunction` operate on the current context. The CUDA runtime
+ * creates and binds its primary context lazily, so force that to have happened.
+ * `cudaFree(nullptr)` is the documented, cheap, idempotent way to do it.
+ */
+inline cudaError_t ensure_context() { return cudaFree(nullptr); }
+
+/** Map a runtime function attribute onto the driver-API enumerator. */
+inline CUfunction_attribute to_driver_attribute(cudaFuncAttribute attr)
+{
+  switch (attr) {
+    case cudaFuncAttributeMaxDynamicSharedMemorySize:
+      return CU_FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES;
+    case cudaFuncAttributePreferredSharedMemoryCarveout:
+      return CU_FUNC_ATTRIBUTE_PREFERRED_SHARED_MEMORY_CARVEOUT;
+    case cudaFuncAttributeRequiredClusterWidth:
+      return CU_FUNC_ATTRIBUTE_REQUIRED_CLUSTER_WIDTH;
+    case cudaFuncAttributeRequiredClusterHeight:
+      return CU_FUNC_ATTRIBUTE_REQUIRED_CLUSTER_HEIGHT;
+    case cudaFuncAttributeRequiredClusterDepth:
+      return CU_FUNC_ATTRIBUTE_REQUIRED_CLUSTER_DEPTH;
+    case cudaFuncAttributeNonPortableClusterSizeAllowed:
+      return CU_FUNC_ATTRIBUTE_NON_PORTABLE_CLUSTER_SIZE_ALLOWED;
+    case cudaFuncAttributeClusterSchedulingPolicyPreference:
+      return CU_FUNC_ATTRIBUTE_CLUSTER_SCHEDULING_POLICY_PREFERENCE;
+    default: return CU_FUNC_ATTRIBUTE_MAX;
+  }
+}
+
+/** Resolve a kernel handle to a `CUfunction` in the current context. */
+inline cudaError_t to_function(CUfunction* function, cudaKernel_t kernel)
+{
+  auto status = ensure_context();
+  if (status != cudaSuccess) { return status; }
+  return from_driver(cuKernelGetFunction(function, reinterpret_cast<CUkernel>(kernel)));
+}
+
+#endif  // !CUVS_RUNTIME_ACCEPTS_KERNEL_HANDLES
+
+}  // namespace detail
+
+/** Set an attribute of a library kernel for one device (`cudaKernelSetAttributeForDevice`). */
+inline cudaError_t kernel_set_attribute(cudaKernel_t kernel,
+                                        cudaFuncAttribute attr,
+                                        int value,
+                                        int device)
+{
+#if CUVS_RUNTIME_ACCEPTS_KERNEL_HANDLES
+  return cudaKernelSetAttributeForDevice(kernel, attr, value, device);
+#else
+  auto status = detail::ensure_context();
+  if (status != cudaSuccess) { return status; }
+  auto driver_attr = detail::to_driver_attribute(attr);
+  if (driver_attr == CU_FUNC_ATTRIBUTE_MAX) { return cudaErrorInvalidValue; }
+  return detail::from_driver(cuKernelSetAttribute(
+    driver_attr, value, reinterpret_cast<CUkernel>(kernel), static_cast<CUdevice>(device)));
+#endif
+}
+
+/** Set an attribute of a library kernel on the current device (`cudaFuncSetAttribute`). */
+inline cudaError_t kernel_set_attribute(cudaKernel_t kernel, cudaFuncAttribute attr, int value)
+{
+#if CUVS_RUNTIME_ACCEPTS_KERNEL_HANDLES
+  return cudaFuncSetAttribute(kernel, attr, value);
+#else
+  int device  = 0;
+  auto status = cudaGetDevice(&device);
+  if (status != cudaSuccess) { return status; }
+  return kernel_set_attribute(kernel, attr, value, device);
+#endif
+}
+
+/**
+ * Read the function attributes of a library kernel (`cudaFuncGetAttributes`).
+ *
+ * On the driver path the struct is filled field by field from `cuFuncGetAttribute`; the fields it
+ * cannot provide keep their zero-initialised values.
+ */
+inline cudaError_t kernel_get_attributes(cudaFuncAttributes* attrs, cudaKernel_t kernel)
+{
+#if CUVS_RUNTIME_ACCEPTS_KERNEL_HANDLES
+  return cudaFuncGetAttributes(attrs, kernel);
+#else
+  CUfunction function{};
+  auto status = detail::to_function(&function, kernel);
+  if (status != cudaSuccess) { return status; }
+
+  *attrs      = cudaFuncAttributes{};
+  auto result = CUDA_SUCCESS;
+  int value{};
+  const auto get = [&](CUfunction_attribute attr, auto& dst) {
+    if (result != CUDA_SUCCESS) { return; }
+    result = cuFuncGetAttribute(&value, attr, function);
+    if (result == CUDA_SUCCESS) { dst = value; }
+  };
+  get(CU_FUNC_ATTRIBUTE_MAX_THREADS_PER_BLOCK, attrs->maxThreadsPerBlock);
+  get(CU_FUNC_ATTRIBUTE_SHARED_SIZE_BYTES, attrs->sharedSizeBytes);
+  get(CU_FUNC_ATTRIBUTE_CONST_SIZE_BYTES, attrs->constSizeBytes);
+  get(CU_FUNC_ATTRIBUTE_LOCAL_SIZE_BYTES, attrs->localSizeBytes);
+  get(CU_FUNC_ATTRIBUTE_NUM_REGS, attrs->numRegs);
+  get(CU_FUNC_ATTRIBUTE_PTX_VERSION, attrs->ptxVersion);
+  get(CU_FUNC_ATTRIBUTE_BINARY_VERSION, attrs->binaryVersion);
+  get(CU_FUNC_ATTRIBUTE_CACHE_MODE_CA, attrs->cacheModeCA);
+  get(CU_FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES, attrs->maxDynamicSharedSizeBytes);
+  get(CU_FUNC_ATTRIBUTE_PREFERRED_SHARED_MEMORY_CARVEOUT, attrs->preferredShmemCarveout);
+  return detail::from_driver(result);
+#endif
+}
+
+/** Occupancy query for a library kernel (`cudaOccupancyMaxActiveBlocksPerMultiprocessor`). */
+inline cudaError_t kernel_max_active_blocks_per_multiprocessor(int* num_blocks,
+                                                               cudaKernel_t kernel,
+                                                               int block_size,
+                                                               std::size_t dynamic_smem_bytes)
+{
+#if CUVS_RUNTIME_ACCEPTS_KERNEL_HANDLES
+  return cudaOccupancyMaxActiveBlocksPerMultiprocessor(
+    num_blocks, kernel, block_size, dynamic_smem_bytes);
+#else
+  CUfunction function{};
+  auto status = detail::to_function(&function, kernel);
+  if (status != cudaSuccess) { return status; }
+  return detail::from_driver(cuOccupancyMaxActiveBlocksPerMultiprocessor(
+    num_blocks, function, block_size, dynamic_smem_bytes));
+#endif
+}
+
+}  // namespace cuvs::util


### PR DESCRIPTION
Use JIT-LTO kernel handles through an API the toolkit actually provides

Part 1 of 2. On its own **this commit changes nothing observable: it is a prerequisite for building cuVS with a CUDA toolkit older than 12.8**, and that becomes possible only in combination with https://github.com/rapidsai/librtcx/pull/17 - "Support CUDA toolkits older than 12.8 via the driver API"

Neither is useful without the other, and either may merge first. The split follows the code: since https://github.com/NVIDIA/cuvs/pull/2311 the JIT-LTO plumbing lives in librtcx, which loads the linked image (`cudaLibraryLoadData` / `cudaLibraryGetKernel` / `cudaLibraryUnload`) and launches it (`cudaLaunchKernelExC`); cuVS keeps only what it does with the resulting handle. Both halves hit the same wall -- the runtime library-management API arrived in CUDA 12.8 -- but they are in different repositories, so they are fixed separately. Without librtcx#17 every cuVS translation unit that includes the rtcx launcher still fails with

> rtcx/algorithm_launcher.hpp:24: error: identifier "cudaLibrary_t" is undefined

(this commit does not change that)

The cuVS half. cuVS queries and sets attributes on the `cudaKernel_t` handles that rtcx hands out for run-time-linked kernels. Both things it does with those handles are CUDA 12.8 features:

* Passing a `cudaKernel_t` where a `"const void* func"` entry point is expected.
  The runtime documents this from 12.8 onwards -- "If the specified function
  does not exist, then it is assumed to be a `cudaKernel_t` and used as is",
  which appears in the 12.8 documentation of `cudaFuncGetAttributes`,
  `cudaFuncSetAttribute` and `cudaOccupancyMaxActiveBlocksPerMultiprocessor` and in
  no earlier version. On an older toolkit the handle is not a valid entry
  address and the call fails with `cudaErrorInvalidDeviceFunction`.

* `cudaKernelSetAttribut`eForDevice, which does not exist before 12.8 in either the headers or libcudart.

The driver API has always taken the equivalent `CUkernel` / `CUfunction`, and `cudaKernel_t` is a `typedef` for `struct CUkern_st*`, i.e. exactly `CUkernel`, so the handles carry over unchanged. Add `src/util/jit_kernel_compat.hpp`, which forwards to the runtime API on 12.8+ and to `cuKernelSetAttribute`, `cuFuncGetAttribute` and `cuOccupancyMaxActiveBlocksPerMultiprocessor` otherwise, and route the six call sites through it. On **12.8+ every wrapper compiles down to the original runtime call** and `CUDA::cuda_driver` is not linked, so nothing changes for the toolkits cuVS supports today.

Two details worth recording:

* The runtime's primary context is forced to exist before any driver call,
  because `cuKernelGetFunction` resolves against the current context. Skipping
  this yields `CUDA_ERROR_INVALID_CONTEXT` from an otherwise correct sequence.

* Driver statuses are translated to the nearest runtime status so that existing
  `RAFT_CUDA_TRY` diagnostics stay meaningful.

In `launchConfigGenerator` the choice between the two occupancy APIs is an `if constexpr` on the argument type, because that helper is also called with genuine `__global__` function pointers, for which the runtime API is correct.

The IVF-PQ kernel selector needed one further change. It asserted that a failed `cudaFuncSetAttribute` was also observable through `cudaGetLastError()`, which only holds for the runtime API; the driver path never sets the runtime's sticky error. The intent -- skip a kernel candidate that cannot get the shared memory it wants -- is preserved, and the sticky error is cleared explicitly.

Verified with CUDA 12.6.85: with https://github.com/rapidsai/librtcx/pull/17 applied (`-DCPM_rtcx_SOURCE=...`),
`libcuvs.so` builds and links for **sm_50**, and CAGRA build and search run correctly on a Maxwell device. Without it, the same tree fails only inside the rtcx headers, which is what _"part 1 of 2"_ means in practice.

Note that dependencies.yaml still lists CUDA 12.2 and 12.5 in its `cuda_version` matrix, so the toolkit range the project declares and the one it can actually build have disagreed since https://github.com/NVIDIA/cuvs/pull/1405.

(Opus 5)