### PR TITLE
Fix CMake discovery for wheel dependencies

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -1609,13 +1609,9 @@ if(NOT BUILD_CPU_ONLY)
              $<BUILD_LOCAL_INTERFACE:$<TARGET_NAME_IF_EXISTS:NCCL::NCCL>>
              $<BUILD_LOCAL_INTERFACE:$<TARGET_NAME_IF_EXISTS:hnswlib::hnswlib>>
              $<$<BOOL:${CUVS_NVTX}>:CUDA::nvtx3>
-      PRIVATE $<TARGET_NAME_IF_EXISTS:OpenMP::OpenMP_CXX>
-              $<COMPILE_ONLY:nvidia::cutlass::cutlass>
-              $<COMPILE_ONLY:cuco::cuco>
-              CUDA::nvJitLink
-              CUDA::nvrtc
-              rtcx::rtcx
-              $<BUILD_LOCAL_INTERFACE:kvikio::kvikio>
+      PRIVATE $<TARGET_NAME_IF_EXISTS:OpenMP::OpenMP_CXX> $<COMPILE_ONLY:nvidia::cutlass::cutlass>
+              $<COMPILE_ONLY:cuco::cuco> CUDA::nvJitLink CUDA::nvrtc rtcx::rtcx kvikio::kvikio
+      INTERFACE $<LINK_ONLY:kvikio::kvikio>
     )
 
     # ensure CUDA symbols aren't relocated to the middle of the debug build binaries

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -9,6 +9,7 @@ include(rapids-cmake)
 include(rapids-cpm)
 include(rapids-export)
 include(rapids-find)
+include(${rapids-cmake-dir}/cython-core/find_prefix_paths.cmake)
 
 option(BUILD_CPU_ONLY "Build CPU only components. Applies to CUVS benchmarks currently" OFF)
 
@@ -27,6 +28,15 @@ project(
   VERSION "${RAPIDS_VERSION}"
   LANGUAGES ${lang_list}
 )
+
+# Find CMake packages provided by installed wheels.
+find_package(Python COMPONENTS Interpreter)
+if(Python_FOUND)
+  rapids_cython_find_prefix_paths("${Python_EXECUTABLE}" wheel_prefix_paths)
+  set_property(GLOBAL PROPERTY FIND_LIBRARY_USE_LIB64_PATHS TRUE)
+  list(PREPEND CMAKE_PREFIX_PATH ${wheel_prefix_paths})
+endif()
+
 set(CMAKE_INSTALL_MESSAGE LAZY)
 
 # Disable C++20 module scanning (not using modules, just C++20 features)

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -9,7 +9,6 @@ include(rapids-cmake)
 include(rapids-cpm)
 include(rapids-export)
 include(rapids-find)
-include(${rapids-cmake-dir}/cython-core/find_prefix_paths.cmake)
 
 option(BUILD_CPU_ONLY "Build CPU only components. Applies to CUVS benchmarks currently" OFF)
 
@@ -32,6 +31,7 @@ project(
 # Find CMake packages provided by installed wheels.
 find_package(Python COMPONENTS Interpreter)
 if(Python_FOUND)
+  include(${rapids-cmake-dir}/cython-core/find_prefix_paths.cmake)
   rapids_cython_find_prefix_paths("${Python_EXECUTABLE}" wheel_prefix_paths)
   set_property(GLOBAL PROPERTY FIND_LIBRARY_USE_LIB64_PATHS TRUE)
   list(PREPEND CMAKE_PREFIX_PATH ${wheel_prefix_paths})

--- a/cpp/cmake/thirdparty/get_kvikio.cmake
+++ b/cpp/cmake/thirdparty/get_kvikio.cmake
@@ -15,15 +15,15 @@ function(find_and_configure_kvikio)
 
   # ----------------------------------------------------------------------------
   # KvikIO provides the GPUDirect Storage (cuFile) and POSIX file I/O backends used by the CAGRA
-  # ACE disk-mode build. Shared cuVS builds consume it privately, while installed static cuVS
-  # targets retain it as a link-only dependency. At runtime the conda 'libkvikio' package provides
-  # both the shared library and its CMake package configuration.
+  # ACE disk-mode build. cuVS consumes it privately, while installed cuVS targets retain it as a
+  # link-only dependency. At runtime package managers provide both the shared library and its CMake
+  # package configuration.
   # ----------------------------------------------------------------------------
   rapids_cpm_find(
     kvikio ${PKG_VERSION}
     GLOBAL_TARGETS kvikio::kvikio
-    BUILD_EXPORT_SET cuvs-static-exports
-    INSTALL_EXPORT_SET cuvs-static-exports
+    BUILD_EXPORT_SET cuvs-exports
+    INSTALL_EXPORT_SET cuvs-exports
     CPM_ARGS
     EXCLUDE_FROM_ALL TRUE
     GIT_REPOSITORY https://github.com/${PKG_FORK}/kvikio.git

--- a/python/cuvs/CMakeLists.txt
+++ b/python/cuvs/CMakeLists.txt
@@ -1,6 +1,6 @@
 # =============================================================================
 # cmake-format: off
-# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 # cmake-format: on
 # =============================================================================
@@ -23,6 +23,9 @@ project(
             # that is fixed we need to keep C.
             C CXX CUDA
 )
+
+# Find C++ libraries from RAPIDS wheels in site-packages.
+set_property(GLOBAL PROPERTY FIND_LIBRARY_USE_LIB64_PATHS TRUE)
 
 # ##################################################################################################
 # * Process User Options  ------------------------------------------------------

--- a/python/libcuvs/CMakeLists.txt
+++ b/python/libcuvs/CMakeLists.txt
@@ -1,6 +1,6 @@
 # =============================================================================
 # cmake-format: off
-# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 # cmake-format: on
 # =============================================================================
@@ -17,6 +17,9 @@ project(
   VERSION "${RAPIDS_VERSION}"
   LANGUAGES CXX CUDA
 )
+
+# Find C++ libraries from RAPIDS wheels in site-packages.
+set_property(GLOBAL PROPERTY FIND_LIBRARY_USE_LIB64_PATHS TRUE)
 
 option(USE_NCCL_RUNTIME_WHEEL "Use the NCCL wheel at runtime instead of the system library" OFF)
 


### PR DESCRIPTION
Adds wheel prefix discovery and propagates KvikIO through the installed cuVS CMake target to fix cuML builds in https://github.com/NVIDIA/cuml/pull/8573.

Part of rapidsai/build-planning#325.