### PR TITLE
Improve CAGRA multi-CTA heuristic: max_iterations

### DIFF
--- a/cpp/src/neighbors/detail/cagra/search_plan.cuh
+++ b/cpp/src/neighbors/detail/cagra/search_plan.cuh
@@ -201,9 +201,13 @@ struct search_plan_impl : public search_plan_impl_base {
     uint32_t _max_iterations = max_iterations;
     if (max_iterations == 0) {
       if (algo == search_algo::MULTI_CTA) {
-        constexpr uint32_t mc_itopk_size   = 32;
-        constexpr uint32_t mc_search_width = 1;
-        _max_iterations                    = mc_itopk_size / mc_search_width;
+        constexpr size_t mc_itopk_size  = 32;
+        const size_t minimum_depth      = 16;
+        const auto effective_itopk_size = raft::ceildiv(itopk_size, mc_itopk_size) * mc_itopk_size;
+        const auto num_ctas = max(search_width, raft::ceildiv(effective_itopk_size, mc_itopk_size));
+
+        _max_iterations = minimum_depth + raft::ceildiv(mc_itopk_size - minimum_depth, num_ctas);
+        _max_iterations += raft::ceildiv(static_cast<size_t>(topk), mc_itopk_size) - 1;
       } else {
         _max_iterations = itopk_size / search_width;
       }


### PR DESCRIPTION
<!--

Thank you for contributing to cuvs :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present) and replace
   it with `[REVIEW]`. If assistance is required to complete the functionality,
   for example when the C/C++ code of a feature is complete but Python bindings
   are still required, then add the label `[HELP-REQ]` so that others can triage
   and assist. The additional changes then can be implemented on top of the
   same PR. If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on master/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against master they should be resolved by merging master
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->

For multi-CTA mode, current `max_iterations` is assigned a large number. However, at low `itopk`, extra iterations only add latency and does not do much to recall. So the intuition is to use a lower `max_iterations` for smaller `itopk`. 

`minimum_depth = 8 * (search_quality - 1)`, since we don't provide a knob for `search_quality` for the moment, hardcoding this to 16. `search_quality = 5` would mean the previous default 32.

 When the problem is harder, or when more results are needed, it is still a good idea to turn up the `max_iterations`.

`n_queries`=1, `k`=10
<img width="1050" height="720" alt="gist_compare_quality_k10_nq1,pareto" src="https://github.com/user-attachments/assets/ab1c28ed-c562-4e76-ac3b-d1538ad117f7" />
<img width="1050" height="720" alt="deep_compare_quality_k10_nq1,pareto" src="https://github.com/user-attachments/assets/1882e249-394b-46fb-a692-031e0a2530df" />

`n_queries`=10, `k`=50
<img width="1050" height="720" alt="gist_compare_quality_k50_nq10,pareto" src="https://github.com/user-attachments/assets/e27a1c50-1581-4d98-b19b-1f42a5912092" />
<img width="1050" height="720" alt="deep_compare_quality_k50_nq10,pareto" src="https://github.com/user-attachments/assets/2ca0d255-e1df-445e-b6a6-f7a234f3b6d2" />

This is a subset of #2502, where the change to width or hashmap size seem to have different effect on different GPU generations, which still remains to be investigated. But the conclusion on `max_iterations` should hold.